### PR TITLE
removing token line

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,8 +103,7 @@ jobs:
           key: cache-key-cpu-py38-{{.Environment.CACHE_VERSION}}-{{checksum "setup.py"}}-{{checksum "requirements.txt"}}
 
       - <<: *run_unittests_with_coverage
-      - codecov/upload:
-          token: ${{ secrets.CODECOV_TOKEN }}
+      - codecov/upload
 
 
   cpu_tests_py38:


### PR DESCRIPTION
Summary:
I got the following errors in
Error calling workflow: 'build'
Error calling job: 'coverage_test_py38'
Error calling command: 'codecov/upload'
Type error for argument token: expected type: env_var_name, actual value: "${{ secrets.CODECOV_TOKEN }}" (type string)

https://app.circleci.com/pipelines/github/facebookresearch/HolisticTraceAnalysis/131

Try with another approach to setup environment variable in https://app.circleci.com/settings/project/github/facebookresearch/HolisticTraceAnalysis/environment-variables?return-to=https%3A%2F%2Fapp.circleci.com%2Fpipelines%2Fgithub%2Ffacebookresearch%2FHolisticTraceAnalysis%3Fbranch%3Dmain

Differential Revision: D45597953

