### PR TITLE
Adding support for H100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 #### Added
+- Added support for H100 traces.
 - (Experimental) Support to read PyTorch Execution Trace and correlate it with PyTorch Profiler Trace.
 
 #### Changed

--- a/hta/analyzers/cuda_kernel_analysis.py
+++ b/hta/analyzers/cuda_kernel_analysis.py
@@ -372,14 +372,16 @@ class CudaKernelAnalysis:
             trace_df: pd.DataFrame = t.get_trace(rank)
 
             # filter out events which have correlation value matching to
-            # cudaLaunchKernel, cudaMemcpyAsync, cudaMemsetAsync
+            # cudaLaunchKernel, cudaLaunchKernelExC, cudaMemcpyAsync, cudaMemsetAsync
             cudaLaunchKernel_id = sym_index.get("cudaLaunchKernel", None)
+            cudaLaunchKernelExC_id = sym_index.get("cudaLaunchKernelExC", None)
             cudaMemcpyAsync_id = sym_index.get("cudaMemcpyAsync", None)
             cudaMemsetAsync_id = sym_index.get("cudaMemsetAsync", None)
 
             # get correlation id's of cudaLaunchKernel events
             cudaLaunchKernel_correlation_series: pd.Series = trace_df[
-                trace_df["name"] == cudaLaunchKernel_id
+                (trace_df["name"] == cudaLaunchKernel_id)
+                | (trace_df["name"] == cudaLaunchKernelExC_id)
             ].correlation
 
             # whether to use memory events - cudaMemsetAsync and cudaMemcpyAsync.

--- a/hta/analyzers/trace_counters.py
+++ b/hta/analyzers/trace_counters.py
@@ -48,6 +48,7 @@ class TraceCounters:
         # cudaLaunchKernel, cudaMemcpyAsync, cudaMemsetAsync
         sym_index = t.symbol_table.get_sym_id_map()
         cudaLaunchKernel_id = sym_index.get("cudaLaunchKernel", None)
+        cudaLaunchKernelExC_id = sym_index.get("cudaLaunchKernelExC", None)
         cudaMemcpyAsync_id = sym_index.get("cudaMemcpyAsync", None)
         cudaMemsetAsync_id = sym_index.get("cudaMemsetAsync", None)
 
@@ -55,7 +56,7 @@ class TraceCounters:
         # - filter events that have a correlated kernel event only.
         runtime_calls: pd.DataFrame = trace_df.query(
             "((name == @cudaMemsetAsync_id) or (name == @cudaMemcpyAsync_id) or "
-            " (name == @cudaLaunchKernel_id))"
+            " (name == @cudaLaunchKernel_id) or (name == @cudaLaunchKernelExC_id))"
             "and (index_correlation > 0)"
         ).copy()
         runtime_calls.drop(["stream", "pid", "tid"], axis=1, inplace=True)

--- a/tests/test_trace_analysis.py
+++ b/tests/test_trace_analysis.py
@@ -28,10 +28,12 @@ class TraceAnalysisTestCase(unittest.TestCase):
         inference_trace_dir: str = "tests/data/inference_single_rank"
         df_index_resolver_trace_dir: str = "tests/data/df_index_resolver"
         rank_non_gpu_trace_dir: str = "tests/data/rank_non_gpu/"
+        h100_trace_dir: str = "tests/data/h100"
         cls.vision_transformer_t = TraceAnalysis(trace_dir=vision_transformer_trace_dir)
         cls.inference_t = TraceAnalysis(trace_dir=inference_trace_dir)
         cls.df_index_resolver_t = TraceAnalysis(trace_dir=df_index_resolver_trace_dir)
         cls.rank_non_gpu_t = TraceAnalysis(trace_dir=rank_non_gpu_trace_dir)
+        cls.h100_trace_t = TraceAnalysis(trace_dir=h100_trace_dir)
 
     def setUp(self):
         self.overlaid_trace_dir = "tests/data"
@@ -104,6 +106,18 @@ class TraceAnalysisTestCase(unittest.TestCase):
         self.assertEqual(row["cpu_duration"].item(), 9)
         self.assertEqual(row["gpu_duration"].item(), 3)
         self.assertEqual(row["launch_delay"].item(), 20)
+
+    def test_get_cuda_kernel_launch_stats_for_h100(self):
+        dataframe_dict = self.h100_trace_t.get_cuda_kernel_launch_stats(
+            ranks=[1], visualize=False
+        )
+        rank_1_df = dataframe_dict[1]
+        row = rank_1_df[rank_1_df["correlation"] == 1281474]
+
+        self.assertEqual(rank_1_df.shape[0], 32835)
+        self.assertEqual(row["cpu_duration"].item(), 20)
+        self.assertEqual(row["gpu_duration"].item(), 31)
+        self.assertEqual(row["launch_delay"].item(), 41)
 
     def test_get_profiler_steps(self):
         results = self.vision_transformer_t.get_profiler_steps()


### PR DESCRIPTION
## What does this PR do?
Fixes #61. 

The `get_cuda_kernel_launch_stats` function returns a dataframe with 31315 rows before this fix and a dataframe of 32835 rows after the fix. This shows that we are tracking `cudaLaunchKernelExC` events now.

## Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [x] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [ ] N/A
