### PR TITLE
Handle floating point counters in cupti counter analysis 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 #### Removed
 
 #### Fixed
+- Fixed issue #65 to handle floating point counter values in cupti\_counter\_analysis.
 
 ## [0.2.0] - 2023-05-22
 #### Added

--- a/hta/analyzers/cupti_counter_analysis.py
+++ b/hta/analyzers/cupti_counter_analysis.py
@@ -93,7 +93,7 @@ class CuptiCounterAnalysis:
 
         def get_top_or_bottom_op(ops: List[int], top: bool) -> int:
             # only get ops that are cpu_op
-            filterd_ops = [op for op in ops if trace_df.loc[op]["cat"] == cpu_op_cat]
+            filterd_ops = [op for op in ops if trace_df["cat"].loc[op] == cpu_op_cat]
             if len(filterd_ops) < 1:
                 return -1
             return filterd_ops[-1 if top else 0]
@@ -112,11 +112,11 @@ class CuptiCounterAnalysis:
             )
         for col in ["top_level_op", "bottom_level_op"]:
             gpu_kernels[col] = gpu_kernels[col].apply(
-                lambda op: sym_table[trace_df.loc[op]["name"]] if op >= 0 else ""
+                lambda op: sym_table[trace_df["name"].loc[op]] if op >= 0 else ""
             )
 
         def stringify_op_stack(ops: List[int]) -> List[str]:
-            return [sym_table[trace_df.loc[op]["name"]] for op in ops]
+            return [sym_table[trace_df["name"].loc[op]] for op in ops]
 
         gpu_kernels["op_stack"] = gpu_kernels["op_stack"].apply(stringify_op_stack)
 


### PR DESCRIPTION
## What does this PR do?
Fixes #65 , The problem comes from indexing a dataframe using loc -> `df.loc[idx]['name']`. When we take a loc and if one of the fields is floating point loc converts all the values to floating point.
[https://stackoverflow.com/.../dtype-integer-but-loc...](https://stackoverflow.com/questions/28460380/dtype-integer-but-loc-returns-float)
The fix interestingly is to index the series first df['name'].loc[idx], this will be correctly of type integer.

## Before submitting
Tested on a notebook with the data from bug, works fine now.

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you update the [changelog] ?(https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [ ] N/A
