### PR TITLE
[2/n] Critical Path analysis for GPU events and CPU->GPU and GPU->CPU dependencies

### DIFF
--- a/hta/analyzers/critical_path_analysis.py
+++ b/hta/analyzers/critical_path_analysis.py
@@ -325,6 +325,7 @@ class CPGraph(nx.DiGraph):
                 # XXX to handle later, stream wait events will likely result in
                 # dependencies between GPU kernels on different streams.
                 return
+            assert name == stream_sync or name == context_sync
 
             # For Context Sync add a sync edge on the last event on all streams,
             # while for Stream Sync only add a sync edge on the specific stream.

--- a/hta/analyzers/critical_path_analysis.py
+++ b/hta/analyzers/critical_path_analysis.py
@@ -284,7 +284,7 @@ class CPGraph(nx.DiGraph):
     def _add_gpu_cpu_sync_edge(self, gpu_node: CPNode, runtime_eid: int) -> None:
         """Add an edge between gpu_node and the runtime event on CPU"""
         _, end_node = self.get_nodes_for_event(runtime_eid)
-        logger.info(f"Adding a sync edge between nodes {gpu_node} -> {end_node}")
+        logger.debug(f"Adding a sync edge between nodes {gpu_node} -> {end_node}")
         self._add_edge_helper(gpu_node, end_node, type=CPEdgeType.SYNC_DEPENDENCY)
 
     def _construct_graph_from_kernels(self) -> None:
@@ -393,8 +393,8 @@ class CPGraph(nx.DiGraph):
         n = 0
         for n in self.nodes:
             node = self.node_list[n]
-            print(f"node id = {n}, node = {node}")
-            print("  neighbors = ", ",".join((str(n) for n in self.neighbors(n))))
+            logger.info(f"node id = {n}, node = {node}")
+            logger.info("  neighbors = ", ",".join((str(n) for n in self.neighbors(n))))
 
     def critical_path(self) -> bool:
         """Calculates the critical path across nodes"""

--- a/hta/analyzers/trace_counters.py
+++ b/hta/analyzers/trace_counters.py
@@ -17,7 +17,9 @@ class TraceCounters:
 
     @classmethod
     def _get_queue_length_time_series_for_rank(
-        cls, t: "Trace", rank: int
+        cls,
+        t: "Trace",
+        rank: int,
     ) -> Optional[pd.DataFrame]:
         """
         Returns an (optional) dataframe with time series for the queue length


### PR DESCRIPTION
## What does this PR do?
This is a follow up to #67 that adds the nodes in the critical path analysis graph for GPU kernels
and in addition we also add the kernel launch delay and synchronization events.

## Details
We update the graph with the following
1. GPU kernels have two nods - begin, end and an edge connecting them.
2. Kernel launch delay - if the CUDA runtime launched a kernel when there was no outstanding kernel on the same stream, we add an edge for the delay in the critical path with the weight = launch delay.
3. Kernel kernel delay - the else case of 2, we add an implicit dependency on the last CUDA kernel executed on the stream.
4. Synchronization - using CUDA sync events we track 
a. Context/Device sync= the last kernel on all streams are a dependency for the Context Sync call on CPU.
b. Stream Sync= the last kernel on the specific stream being synced is a dependency for the Stream Sync runtime call on CPU.


Event sync is handled in the next PR.

## Test/Examples

Running this on simple add test.
We can see the edges for kernel launch and kernel-kernel delay. 
![Screenshot 2023-10-05 at 11 04 36 AM](https://github.com/facebookresearch/HolisticTraceAnalysis/assets/6922212/85171347-ff50-4c23-9e60-f5d3f6f3fefc)

The example below shows Context Sync event (pink on the right), there are two edges coming in, one each from the last kernel on each CUDA stream.

![Screenshot 2023-10-05 at 11 05 16 AM](https://github.com/facebookresearch/HolisticTraceAnalysis/assets/6922212/78f9a33f-769c-43b2-bd37-982d12b28bd1)

The final critical path shifts from CPU to GPU in the end of the iteration - highlighted events are on critical path.

![Screenshot 2023-10-05 at 11 06 27 AM](https://github.com/facebookresearch/HolisticTraceAnalysis/assets/6922212/9da54aec-9eb1-4244-99b4-b03a92e51d2b)


## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [x] N/A
