### PR TITLE
[4/n] Improve Critical path vizualization

### DIFF
--- a/examples/experimental/critical_path_analysis.ipynb
+++ b/examples/experimental/critical_path_analysis.ipynb
@@ -33,12 +33,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2023-10-02 15:50:20,665 - hta - trace.py:L414 - INFO - /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/critical_path/simple_add\n",
-      "2023-10-02 15:50:20,675 - hta - trace_file.py:L94 - INFO - Rank to trace file map:\n",
+      "2023-10-09 15:27:39,303 - hta - trace.py:L414 - INFO - /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/critical_path/simple_add\n",
+      "2023-10-09 15:27:39,333 - hta - trace_file.py:L94 - INFO - Rank to trace file map:\n",
       "{0: '/Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/critical_path/simple_add/benchmark_result_493459_1694039959_trace.json.gz'}\n",
-      "2023-10-02 15:50:20,678 - hta - trace.py:L560 - INFO - ranks=[0]\n",
-      "2023-10-02 15:50:20,701 - hta - trace.py:L142 - INFO - Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/critical_path/simple_add/benchmark_result_493459_1694039959_trace.json.gz time = 0.01 seconds \n",
-      "2023-10-02 15:50:20,758 - hta - trace.py:L696 - WARNING - ProfilerStep not found in the trace. The analysis result may not be accurate.\n"
+      "2023-10-09 15:27:39,337 - hta - trace.py:L560 - INFO - ranks=[0]\n",
+      "2023-10-09 15:27:39,358 - hta - trace.py:L142 - INFO - Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/critical_path/simple_add/benchmark_result_493459_1694039959_trace.json.gz time = 0.02 seconds \n",
+      "2023-10-09 15:27:39,412 - hta - trace.py:L696 - WARNING - ProfilerStep not found in the trace. The analysis result may not be accurate.\n"
      ]
     }
    ],
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 2,
    "id": "ca7b1630-9905-437a-92f2-34d3b84d048d",
    "metadata": {},
    "outputs": [
@@ -121,7 +121,7 @@
        "This will include GPU kernels launched by the cpu operators in that\n",
        "time duration.\n",
        "For example, you can use this to limit the analysis to one iteration\n",
-       "by passing annotation='ProfilerStep500'. See notes for how to pick the iteraiton.\n",
+       "by passing annotation='ProfilerStep500'. See notes for how to pick the iteration.\n",
        "\n",
        "Args:\n",
        "    t (Trace): Input trace data structure.\n",
@@ -162,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 3,
    "id": "1debaba3-bbac-498b-8f6f-a0b69658e6b3",
    "metadata": {},
    "outputs": [],
@@ -173,7 +173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
    "id": "4e8affb1-74f2-4b88-a6eb-85d3a1b67c79",
    "metadata": {},
    "outputs": [
@@ -181,8 +181,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2023-10-02 15:51:28,706 - hta - critical_path_analysis.py:L356 - INFO - Looking up events under 1 instance of '[param|pytorch.model.alex_net|0|0|0|measure|forward]' annotation\n",
-      "2023-10-02 15:51:28,730 - hta - critical_path_analysis.py:L383 - INFO - Clipped dataframe has 212 events\n"
+      "2023-10-09 15:27:39,473 - hta - critical_path_analysis.py:L493 - INFO - Looking up events under 1 instance of '[param|pytorch.model.alex_net|0|0|0|measure|forward]' annotation\n",
+      "2023-10-09 15:27:39,483 - hta - critical_path_analysis.py:L520 - INFO - Clipped dataframe has 212 events\n",
+      "2023-10-09 15:27:39,518 - hta - critical_path_analysis.py:L321 - INFO - CUDA Sync event eid = 975.0, name = Context Sync\n",
+      "2023-10-09 15:27:39,519 - hta - critical_path_analysis.py:L321 - INFO - CUDA Sync event eid = 1029.0, name = Stream Wait Event\n",
+      "2023-10-09 15:27:39,520 - hta - critical_path_analysis.py:L321 - INFO - CUDA Sync event eid = 1075.0, name = Stream Wait Event\n",
+      "2023-10-09 15:27:39,525 - hta - critical_path_analysis.py:L321 - INFO - CUDA Sync event eid = 1279.0, name = Context Sync\n"
      ]
     },
     {
@@ -191,7 +195,7 @@
        "True"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -208,14 +212,25 @@
    "metadata": {},
    "source": [
     "## Overlay and visualize the Critical Path\n",
-    "1. In the output trace file search for \"critical\" to highlight events on the critical path.\n",
-    "1. Edges in the critical path graph will be shown using arrows or flow events. The category names of flow events begin with \"critical_path_\"."
+    "The `overlay_critical_path_analysis()` function exposes the critical path on the original trace file.\n",
+    "There are two modes for the output:\n",
+    "1. When `only_show_critical_events=True` (default value) the output trace only contains CPU operators and GPU events on the critical path. One can compare it with the original trace to contrast the critical path identified by the algorithm.\n",
+    "1. When `only_show_critical_events=True` in the output trace file search for \"critical\" to highlight events on the critical path.\n",
+    "\n",
+    "Edges in the critical path graph will be shown using arrows or flow events. Critical edges are marked using the \"critical\" flag in the args property.\n",
+    "\n",
+    "The category names of flow events begin with \"critical_path_\". They have the following meaning:\n",
+    "* `critical_path_dependency`: an inter operator dependency.\n",
+    "* `critical_path_operator`: an edge between start and end of a CPU operator or GPU kernel.\n",
+    "* `critical_path_kernel_launch_delay`: delay to launch a GPU kernel that is likely to be on the critical path.\n",
+    "* `critical_path_kernel_kernel_delay`: delay between running successive GPU kernels.\n",
+    "* `critical_path_sync_dependency`: these edges denote synchronization or control dependencies between events such as GPU->CPU, GPU->GPU synchronization."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "8c0bdf7f-0291-4461-a2d8-e78aeb811af6",
+   "execution_count": 5,
+   "id": "19434b4f-9799-40f3-b6df-ec99fce37246",
    "metadata": {},
    "outputs": [
     {
@@ -226,6 +241,7 @@
        "\u001b[0;34m\u001b[0m    \u001b[0mrank\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mint\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0mcritical_path_graph\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mhta\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0manalyzers\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcritical_path_analysis\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mCPGraph\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0moutput_dir\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0monly_show_critical_events\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mbool\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0mshow_all_edges\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mbool\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m->\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
        "\u001b[0;31mDocstring:\u001b[0m\n",
@@ -235,7 +251,10 @@
        "Args:\n",
        "    rank (int): rank to generate the time series for.\n",
        "    critical_path_graph: Critical Path Graph object generated previously\n",
-       "    output_dir (str): Output director to store overlaid trace.\n",
+       "    output_dir (str): Output directory to store overlaid trace.\n",
+       "    only_show_critical_events (bool): When set the output trace will only\n",
+       "        have operators and GPU kernels on the critical path. It will\n",
+       "        still retain the user annotations.\n",
        "    show_all_edges (bool): When set this will add edge events for\n",
        "        all types of edges in the critical path graph. This is useful\n",
        "        for debugging the algorithm.\n",
@@ -257,7 +276,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 6,
    "id": "65e20368-2e85-48f1-af48-60d334ec90a2",
    "metadata": {},
    "outputs": [
@@ -265,7 +284,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2023-10-02 15:52:19,448 - hta - trace.py:L142 - INFO - Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/critical_path/simple_add/benchmark_result_493459_1694039959_trace.json.gz time = 0.02 seconds \n"
+      "2023-10-09 15:28:45,797 - hta - trace.py:L142 - INFO - Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/critical_path/simple_add/benchmark_result_493459_1694039959_trace.json.gz time = 0.01 seconds \n"
      ]
     },
     {
@@ -274,7 +293,7 @@
        "'/Users/bcoutinho/Work/hta/critical_path/simple_add/overlaid/overlaid_critical_path_benchmark_result_493459_1694039959_trace.json.gz'"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -283,7 +302,7 @@
     "# Make sure '~/HolisticTraceAnalysis/tests/data/critical_path/simple_add/overlaid' exists or add a different directory\n",
     "# to write your trace too.\n",
     "analyzer.overlay_critical_path_analysis(\n",
-    "    0, cp_graph, output_dir='~/HolisticTraceAnalysis2/tests/data/critical_path/simple_add/overlaid', show_all_edges=True)"
+    "    0, cp_graph, output_dir='~/HolisticTraceAnalysis/tests/data/critical_path/simple_add/overlaid', show_all_edges=True)"
    ]
   },
   {
@@ -296,7 +315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 7,
    "id": "8b70c7e2-103c-475a-b030-356fc6f4d4ee",
    "metadata": {},
    "outputs": [
@@ -318,6 +337,7 @@
        "    node_list (List[int]): list of critical path node objects, index in this list is always the node id..\n",
        "    critical_path_nodes (List[int]): list of node ids on the critical path.\n",
        "    critical_path_events_set (Set[int]): set of event ids corresponding to the critical path nodes.\n",
+       "    critical_path_edges_set (Set[CPEdge]): set of edge objects that are on the critical path.\n",
        "\u001b[0;31mInit docstring:\u001b[0m\n",
        "Initialize a graph with edges, name, or graph attributes.\n",
        "\n",

--- a/hta/analyzers/critical_path_analysis.py
+++ b/hta/analyzers/critical_path_analysis.py
@@ -47,7 +47,7 @@ class CPEdgeType(Enum):
     SYNC_DEPENDENCY = "critical_path_sync_dependency"
 
 
-@dataclass
+@dataclass(frozen=True)
 class CPEdge:
     """An edge in the critical path di-graph.
     This represents either a
@@ -82,6 +82,7 @@ class CPGraph(nx.DiGraph):
         node_list (List[int]): list of critical path node objects, index in this list is always the node id..
         critical_path_nodes (List[int]): list of node ids on the critical path.
         critical_path_events_set (Set[int]): set of event ids corresponding to the critical path nodes.
+        critical_path_edges_set (Set[CPEdge]): set of edge objects that are on the critical path.
     """
 
     def __init__(self, t: "Trace", rank: int) -> None:
@@ -91,6 +92,7 @@ class CPGraph(nx.DiGraph):
         self.symbol_table = t.symbol_table
         self.critical_path_nodes: List[int] = []
         self.critical_path_events_set: Set[int] = set()
+        self.critical_path_edges_set: Set[CPEdge] = set()
 
         self.t = t
         self.rank: int = rank
@@ -532,16 +534,26 @@ class CPGraph(nx.DiGraph):
         except nx.NetworkXUnfeasible as err:
             logger.error(f"Critical path algorithm failed due to {err}")
             return False
+        assert len(self.critical_path_nodes) >= 2
+
         self.critical_path_events_set = {
             self.node_list[nid].ev_idx for nid in self.critical_path_nodes
         }
+
+        critical_path_nodes_set = set(self.critical_path_nodes)
+
+        for u, v in self.edges:
+            e = self.edges[u, v]["object"]
+            if u in critical_path_nodes_set and v in critical_path_nodes_set:
+                self.critical_path_edges_set.add(e)
+
         return True
 
     def show_critical_path(self) -> None:
         """List out the nodes in the critical path graph"""
         for n in self.critical_path_nodes:
             node = self.node_list[n]
-            print(
+            logger.info(
                 f"Critical {node}, ev_id = {node.ev_idx} "
                 f"ev_name = {self._get_node_name(node.ev_idx)}"
             )
@@ -651,7 +663,8 @@ class CriticalPathAnalysis:
         rank: int,
         critical_path_graph: CPGraph,
         output_dir: str,
-        show_all_edges: bool = False,
+        only_show_critical_events: bool,
+        show_all_edges: bool,
     ) -> str:
         r"""
         Overlay the identified critical path on top of the trace file
@@ -660,14 +673,21 @@ class CriticalPathAnalysis:
         Args:
             t (Trace): Input trace data structure.
             rank (int): rank to generate the time series for.
-            critical_path_graph: Critical Path Graph object generated previously
+            critical_path_graph: Critical Path Graph object generated previously.
             output_dir (str): Output directory to store overlaid trace.
+            only_show_critical_events (bool): When set the output trace will only
+                have operators and GPU kernels on the critical path. It will
+                still retain the user annotations.
             show_all_edges (bool): When set this will add edge events for
                 all types of edges in the critical path graph. This is useful
-                for debugging the algorithm.
+                for debugging the algorithm. The value will be forced to False
+                if only_show_critical_events is True.
 
         Returns: the overlaid_trace_file path.
         """
+        if only_show_critical_events:
+            show_all_edges = False
+
         path = Path(output_dir).expanduser()
         if not path.exists():
             logger.error(f"The path {str(path)} does not exist.")
@@ -691,12 +711,18 @@ class CriticalPathAnalysis:
         flow_id = 0
 
         def get_flow_event(
-            nid: int, event: Dict[str, Any], edge: CPEdge, flow_id: int, is_start: bool
+            nid: int,
+            event: Dict[str, Any],
+            edge: CPEdge,
+            flow_id: int,
+            is_start: bool,
         ):
             # This helps with showing the arrows in chrome trace
             end_ts = event["ts"] + event["dur"]
             if event["args"].get("device", -1) >= 0:
                 end_ts -= min(1, event["dur"])
+
+            is_critical = e in critical_path_graph.critical_path_edges_set
 
             return Trace.flow_event(
                 id=flow_id,
@@ -710,20 +736,25 @@ class CriticalPathAnalysis:
                 is_start=is_start,
                 name="critical_path",
                 cat=str(edge.type.value),
-                args={"weight": int(edge.weight)},
+                args={
+                    "weight": int(edge.weight),
+                    "critical": is_critical,
+                },
             )
 
-        # Networkx provides iteration over the edges represented as (u, v)
-        for u, v in critical_path_graph.edges:
-            e = critical_path_graph.edges[u, v]["object"]
+        if show_all_edges:
+            # Networkx provides iteration over the edges represented as (u, v)
+            edges = (
+                critical_path_graph.edges[u, v]["object"]
+                for u, v in critical_path_graph.edges
+            )
+        else:
+            edges = (e for e in critical_path_graph.critical_path_edges_set)
+
+        for e in edges:
+            u, v = e.begin, e.end
             start_ev_id, end_ev_id = critical_path_graph.get_events_for_edge(e)
             start_ev, end_ev = raw_events[start_ev_id], raw_events[end_ev_id]
-
-            if (
-                e.type in {CPEdgeType.OPERATOR_KERNEL, CPEdgeType.KERNEL_KERNEL_DELAY}
-                and not show_all_edges
-            ):
-                continue
 
             # XXX need to assert if raw event name and dataframe name are same
             logger.debug(f"Adding cp edge between {start_ev_id} and {end_ev_id}")
@@ -732,7 +763,21 @@ class CriticalPathAnalysis:
             flow_events.append(get_flow_event(v, end_ev, e, flow_id, is_start=False))
             flow_id += 1
 
-        raw_events.extend(flow_events)
+        if only_show_critical_events:
+            raw_events2 = [
+                event
+                for event in raw_events
+                if (
+                    event["ph"] != "X"
+                    or event.get("cat", "") in ["user_annotation"]
+                    or ("args" in event and event["args"].get("critical", 0) == 1)
+                )
+            ]
+            logger.info("len of new raw events = {raw_events2}")
+            overlaid_trace["traceEvents"] = raw_events2
+
+        overlaid_trace["traceEvents"].extend(flow_events)
+
         t.write_raw_trace(output_file, overlaid_trace)
 
         return output_file

--- a/hta/analyzers/critical_path_analysis.py
+++ b/hta/analyzers/critical_path_analysis.py
@@ -678,10 +678,12 @@ class CriticalPathAnalysis:
             only_show_critical_events (bool): When set the output trace will only
                 have operators and GPU kernels on the critical path. It will
                 still retain the user annotations.
+                Default value = True.
             show_all_edges (bool): When set this will add edge events for
                 all types of edges in the critical path graph. This is useful
                 for debugging the algorithm. The value will be forced to False
                 if only_show_critical_events is True.
+                Default value = False.
 
         Returns: the overlaid_trace_file path.
         """
@@ -773,7 +775,7 @@ class CriticalPathAnalysis:
                     or ("args" in event and event["args"].get("critical", 0) == 1)
                 )
             ]
-            logger.info("len of new raw events = {raw_events2}")
+            logger.debug("Length of new raw events = {raw_events2}")
             overlaid_trace["traceEvents"] = raw_events2
 
         overlaid_trace["traceEvents"].extend(flow_events)

--- a/hta/trace_analysis.py
+++ b/hta/trace_analysis.py
@@ -557,6 +557,7 @@ class TraceAnalysis:
         rank: int,
         critical_path_graph: CPGraph,
         output_dir: str,
+        only_show_critical_events: bool = True,
         show_all_edges: bool = False,
     ) -> str:
         r"""
@@ -567,6 +568,9 @@ class TraceAnalysis:
             rank (int): rank to generate the time series for.
             critical_path_graph: Critical Path Graph object generated previously
             output_dir (str): Output directory to store overlaid trace.
+            only_show_critical_events (bool): When set the output trace will only
+                have operators and GPU kernels on the critical path. It will
+                still retain the user annotations.
             show_all_edges (bool): When set this will add edge events for
                 all types of edges in the critical path graph. This is useful
                 for debugging the algorithm.
@@ -576,5 +580,10 @@ class TraceAnalysis:
         to the original trace file.
         """
         return CriticalPathAnalysis.overlay_critical_path_analysis(
-            self.t, rank, critical_path_graph, output_dir, show_all_edges
+            self.t,
+            rank,
+            critical_path_graph,
+            output_dir,
+            only_show_critical_events,
+            show_all_edges,
         )


### PR DESCRIPTION
## What does this PR do?
In the overlaid trace file we add an option to only show critical path CPU and GPU operators. Also only show edges on the critical path.

Details
* Update API, and update notebook documentation
* Implement trimming events in the trace.
* Update unit tests for this feature

## TestPlan
Ran on test trace - only critical path shows up
![Screenshot 2023-10-09 at 4 16 04 PM](https://github.com/facebookresearch/HolisticTraceAnalysis/assets/6922212/98b9d821-9dad-42a4-8d2b-438ae93c4d9d)


New unittest

## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [ ] N/A
