### PR TITLE
Do not change logger on the import time

### DIFF
--- a/hta/configs/config.py
+++ b/hta/configs/config.py
@@ -28,7 +28,7 @@ def setup_logger(config_file: str = "logging.config") -> logging.Logger:
     return logger
 
 
-logger: logging.Logger = setup_logger()
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 class HtaConfig:


### PR DESCRIPTION
Summary: Setting up loggers and in general executing logic with side-effect on the import time is a really bad idea. It messes with the logging setup of other projects even when this logic is not used. Logging should only be set up in the entry point, not on the module import time.

Reviewed By: krishnakumar-kapil

Differential Revision: D49770131


