### PR TITLE
Critical path analysis improvements and fixes

### DIFF
--- a/examples/experimental/critical_path_analysis.ipynb
+++ b/examples/experimental/critical_path_analysis.ipynb
@@ -30,22 +30,18 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-10-09 15:27:39,303 - hta - trace.py:L414 - INFO - /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/critical_path/simple_add\n",
-      "2023-10-09 15:27:39,333 - hta - trace_file.py:L94 - INFO - Rank to trace file map:\n",
-      "{0: '/Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/critical_path/simple_add/benchmark_result_493459_1694039959_trace.json.gz'}\n",
-      "2023-10-09 15:27:39,337 - hta - trace.py:L560 - INFO - ranks=[0]\n",
-      "2023-10-09 15:27:39,358 - hta - trace.py:L142 - INFO - Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/critical_path/simple_add/benchmark_result_493459_1694039959_trace.json.gz time = 0.02 seconds \n",
-      "2023-10-09 15:27:39,412 - hta - trace.py:L696 - WARNING - ProfilerStep not found in the trace. The analysis result may not be accurate.\n"
+      "ProfilerStep not found in the trace. The analysis result may not be accurate.\n"
      ]
     }
    ],
    "source": [
     "from hta.trace_analysis import TraceAnalysis\n",
     "\n",
-    "trace_dir = \"<UPDATE THIS PATH>/tests/data/critical_path/simple_add/\"\n",
+    "trace_dir = \"/Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/critical_path/simple_add/\"\n",
+    "\n",
     "analyzer = TraceAnalysis(trace_dir=trace_dir)"
    ]
   },
@@ -111,7 +107,7 @@
        "\u001b[0manalyzer\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcritical_path_analysis\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0mrank\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mint\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0mannotation\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0minstance_id\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mint\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0minstance_id\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mUnion\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mint\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mNoneType\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mTuple\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mint\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mint\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m->\u001b[0m \u001b[0mTuple\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mhta\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0manalyzers\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcritical_path_analysis\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mCPGraph\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbool\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
        "\u001b[0;31mDocstring:\u001b[0m\n",
        "Perform critical path analysis for trace events within a rank.\n",
@@ -121,15 +117,20 @@
        "This will include GPU kernels launched by the cpu operators in that\n",
        "time duration.\n",
        "For example, you can use this to limit the analysis to one iteration\n",
-       "by passing annotation='ProfilerStep500'. See notes for how to pick the iteration.\n",
+       "by passing annotation='ProfilerStep'. See notes for how to pick the iteration.\n",
        "\n",
        "Args:\n",
        "    t (Trace): Input trace data structure.\n",
        "    rank (int): rank to analyze for the critical path.\n",
        "    annotation (str): a trace annotation to limit the analysis to,\n",
-       "        such as \"ProfilerStep500\"\n",
-       "    instance_id (int): optionally specify which instance of the annotation\n",
-       "        to consider. Defaults to the first instance.\n",
+       "        for example \"ProfilerStep\" would match all annotations that\n",
+       "        match this string (ProfilerStep100, ProfilerStep101 etc)\n",
+       "    instance_id: can be either of the following\n",
+       "        (int) - specify which instance of the annotation to consider. \n",
+       "                Defaults to the first instance.\n",
+       "        (Tuple(int, int)) - considers a range of annotation instances start to end,\n",
+       "                inclusive of both start and end instance.\n",
+       "\n",
        "\n",
        "Returns: Tuple[CPGraph, bool] a pair of CPGraph object and a success or\n",
        "    fail boolean value. True indicates that the critical path analysis\n",
@@ -168,7 +169,11 @@
    "outputs": [],
    "source": [
     "annotation = \"[param|pytorch.model.alex_net|0|0|0|measure|forward]\"\n",
-    "instance_id = 1"
+    "instance_id = 1  # note this is zero based\n",
+    "\n",
+    "# You can also pass a tuple specifying range of annotation instances\n",
+    "# annotation = \"ProfilerStep\"  # will match multiple ProfilerStepXXX annotations\n",
+    "# instance_id = (2,3)          # include 3rd to 4th iteration."
    ]
   },
   {
@@ -178,15 +183,11 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-10-09 15:27:39,473 - hta - critical_path_analysis.py:L493 - INFO - Looking up events under 1 instance of '[param|pytorch.model.alex_net|0|0|0|measure|forward]' annotation\n",
-      "2023-10-09 15:27:39,483 - hta - critical_path_analysis.py:L520 - INFO - Clipped dataframe has 212 events\n",
-      "2023-10-09 15:27:39,518 - hta - critical_path_analysis.py:L321 - INFO - CUDA Sync event eid = 975.0, name = Context Sync\n",
-      "2023-10-09 15:27:39,519 - hta - critical_path_analysis.py:L321 - INFO - CUDA Sync event eid = 1029.0, name = Stream Wait Event\n",
-      "2023-10-09 15:27:39,520 - hta - critical_path_analysis.py:L321 - INFO - CUDA Sync event eid = 1075.0, name = Stream Wait Event\n",
-      "2023-10-09 15:27:39,525 - hta - critical_path_analysis.py:L321 - INFO - CUDA Sync event eid = 1279.0, name = Context Sync\n"
+      "WARNING:hta.configs.config:CUDA Stream Wait event was not matched to a cudaRecordEvent, name = Stream Wait Event\n",
+      "WARNING:hta.configs.config:CUDA Stream Wait event was not matched to a cudaRecordEvent, name = Stream Wait Event\n"
      ]
     },
     {
@@ -215,7 +216,7 @@
     "The `overlay_critical_path_analysis()` function exposes the critical path on the original trace file.\n",
     "There are two modes for the output:\n",
     "1. When `only_show_critical_events=True` (default value) the output trace only contains CPU operators and GPU events on the critical path. One can compare it with the original trace to contrast the critical path identified by the algorithm.\n",
-    "1. When `only_show_critical_events=True` in the output trace file search for \"critical\" to highlight events on the critical path.\n",
+    "1. When `only_show_critical_events=False` in the output trace file search for \"critical\" to highlight events on the critical path.\n",
     "\n",
     "Edges in the critical path graph will be shown using arrows or flow events. Critical edges are marked using the \"critical\" flag in the args property.\n",
     "\n",
@@ -281,13 +282,6 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2023-10-09 15:28:45,797 - hta - trace.py:L142 - INFO - Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/critical_path/simple_add/benchmark_result_493459_1694039959_trace.json.gz time = 0.01 seconds \n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
        "'/Users/bcoutinho/Work/hta/critical_path/simple_add/overlaid/overlaid_critical_path_benchmark_result_493459_1694039959_trace.json.gz'"
@@ -302,7 +296,7 @@
     "# Make sure '~/HolisticTraceAnalysis/tests/data/critical_path/simple_add/overlaid' exists or add a different directory\n",
     "# to write your trace too.\n",
     "analyzer.overlay_critical_path_analysis(\n",
-    "    0, cp_graph, output_dir='~/HolisticTraceAnalysis/tests/data/critical_path/simple_add/overlaid', show_all_edges=True)"
+    "    0, cp_graph, output_dir='~/HolisticTraceAnalysis/tests/data/critical_path/simple_add/overlaid')"
    ]
   },
   {
@@ -315,69 +309,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "8b70c7e2-103c-475a-b030-356fc6f4d4ee",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mInit signature:\u001b[0m \u001b[0mCPGraph\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mt\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;34m'Trace'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrank\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mint\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m->\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-       "\u001b[0;31mDocstring:\u001b[0m     \n",
-       "Critical path analysis graph representation for trace from one rank.\n",
-       "This object constructs a graph that can be analyzed using networkx library.\n",
-       "\n",
-       "We maintain a mapping between node ids -> CPNode objects\n",
-       "and use the integer as a node in the networkx graph datastructure.\n",
-       "Edges are directly used as the type is hashable.\n",
-       "\n",
-       "Attributes:\n",
-       "    trace_df (pd.DataFrame): dataframe of trace events used to construct this graph.\n",
-       "    symbol_table (TraceSymbolTable): a symbol table used to encode the symbols in the trace.\n",
-       "    node_list (List[int]): list of critical path node objects, index in this list is always the node id..\n",
-       "    critical_path_nodes (List[int]): list of node ids on the critical path.\n",
-       "    critical_path_events_set (Set[int]): set of event ids corresponding to the critical path nodes.\n",
-       "    critical_path_edges_set (Set[CPEdge]): set of edge objects that are on the critical path.\n",
-       "\u001b[0;31mInit docstring:\u001b[0m\n",
-       "Initialize a graph with edges, name, or graph attributes.\n",
-       "\n",
-       "Parameters\n",
-       "----------\n",
-       "incoming_graph_data : input graph (optional, default: None)\n",
-       "    Data to initialize graph.  If None (default) an empty\n",
-       "    graph is created.  The data can be an edge list, or any\n",
-       "    NetworkX graph object.  If the corresponding optional Python\n",
-       "    packages are installed the data can also be a 2D NumPy array, a\n",
-       "    SciPy sparse array, or a PyGraphviz graph.\n",
-       "\n",
-       "attr : keyword arguments, optional (default= no attributes)\n",
-       "    Attributes to add to graph as key=value pairs.\n",
-       "\n",
-       "See Also\n",
-       "--------\n",
-       "convert\n",
-       "\n",
-       "Examples\n",
-       "--------\n",
-       ">>> G = nx.Graph()  # or DiGraph, MultiGraph, MultiDiGraph, etc\n",
-       ">>> G = nx.Graph(name=\"my graph\")\n",
-       ">>> e = [(1, 2), (2, 3), (3, 4)]  # list of edges\n",
-       ">>> G = nx.Graph(e)\n",
-       "\n",
-       "Arbitrary graph attribute pairs (key=value) may be assigned\n",
-       "\n",
-       ">>> G = nx.Graph(e, day=\"Friday\")\n",
-       ">>> G.graph\n",
-       "{'day': 'Friday'}\n",
-       "\u001b[0;31mFile:\u001b[0m           ~/Work/hta/HolisticTraceAnalysis2/hta/analyzers/critical_path_analysis.py\n",
-       "\u001b[0;31mType:\u001b[0m           type\n",
-       "\u001b[0;31mSubclasses:\u001b[0m     "
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from hta.analyzers.critical_path_analysis import CPGraph\n",
     "CPGraph?"

--- a/examples/experimental/critical_path_analysis.ipynb
+++ b/examples/experimental/critical_path_analysis.ipynb
@@ -124,7 +124,7 @@
        "    rank (int): rank to analyze for the critical path.\n",
        "    annotation (str): a trace annotation to limit the analysis to,\n",
        "        for example \"ProfilerStep\" would match all annotations that\n",
-       "        match this string (ProfilerStep100, ProfilerStep101 etc)\n",
+       "        match this string (ProfilerStep#100, ProfilerStep#101 etc)\n",
        "    instance_id: can be either of the following\n",
        "        (int) - specify which instance of the annotation to consider. \n",
        "                Defaults to the first instance.\n",

--- a/hta/analyzers/critical_path_analysis.py
+++ b/hta/analyzers/critical_path_analysis.py
@@ -735,9 +735,7 @@ class CriticalPathAnalysis:
             )
 
         annotation_id = sym_index.get(annotation, None)
-        annotation_ids = [
-            val for key, val in sym_index.items() if annotation in key
-        ]
+        annotation_ids = [val for key, val in sym_index.items() if annotation in key]
 
         if len(annotation_ids) == 0:
             logger.error(f"Could not find annotation {annotation} in the trace.")
@@ -779,9 +777,7 @@ class CriticalPathAnalysis:
         b = (
             gpu_kernels[["ts", "dur", "correlation"]]
             .join(cpu_kernels["ts"], rsuffix="_runtime")
-            .query(
-                f"(ts_runtime >= {start_ts} and ts_runtime <= {end_ts}) and dur > 0"
-            )
+            .query(f"(ts_runtime >= {start_ts} and ts_runtime <= {end_ts}) and dur > 0")
         )
 
         clipped_df = trace_df.loc[a.index.union(b.index)].copy()

--- a/hta/analyzers/critical_path_analysis.py
+++ b/hta/analyzers/critical_path_analysis.py
@@ -697,18 +697,19 @@ class CriticalPathAnalysis:
         a trace annotation and instance id. This will
         limit the analysis to events within the time range of that annoation.
         For example, you can use this to limit the analysis to one iteration
-        by passing annotation='ProfilerStep500'.
+        by passing annotation='ProfilerStep'.
 
         Args:
             t (Trace): Input trace data structure.
             rank (int): rank to analyze for the critical path.
             annotation (str): a trace annotation to limit the analysis to,
                 for example "ProfilerStep" would match all annotations that
-                match this string.
-            instance_id:
-                (int) - optionally specify which instance of the annotation
-                to consider. Defaults to the first instance.
-                (Tuple(int, int))
+                match this string (ProfilerStep100, ProfilerStep101 etc)
+            instance_id: can be either of the following
+                (int) - specify which instance of the annotation to consider. 
+                        Defaults to the first instance.
+                (Tuple(int, int)) - considers a range of annotation instances start to end,
+                        inclusive of both start and end instance.
 
         Returns: Tuple[CPGraph, bool] a pair of CPGraph object and a success or
             fail boolean value. True indicates that the critical path analysis

--- a/hta/analyzers/critical_path_analysis.py
+++ b/hta/analyzers/critical_path_analysis.py
@@ -329,7 +329,7 @@ class CPGraph(nx.DiGraph):
         """For Event based synchronization we need to track the next
         kernel/memcpy launched on a CPU thread just juast after cudaStreamWaitEvent
 
-        This function returns a dataframe of cudaEventRecord events,
+        This function returns a dataframe of cudaStreamWaitEvent events,
         and includes an additional column 'index_next_launch'
         that specifies the closest CUDA kernel launch on the same CPU thread
         and associated CUDA stream.
@@ -706,7 +706,7 @@ class CriticalPathAnalysis:
                 for example "ProfilerStep" would match all annotations that
                 match this string (ProfilerStep100, ProfilerStep101 etc)
             instance_id: can be either of the following
-                (int) - specify which instance of the annotation to consider. 
+                (int) - specify which instance of the annotation to consider.
                         Defaults to the first instance.
                 (Tuple(int, int)) - considers a range of annotation instances start to end,
                         inclusive of both start and end instance.

--- a/hta/analyzers/critical_path_analysis.py
+++ b/hta/analyzers/critical_path_analysis.py
@@ -631,8 +631,8 @@ class CPGraph(nx.DiGraph):
                 edge_added = True
             elif not edge_added:
                 # Neither of Sync, kernel-kernel or kernel launch edges were added
-                logger.error(
-                    f"Final fall through Queue length is {queue_length_runtime}!= 1 but no "
+                logger.warning(
+                    f"No edge was added - queue length is {queue_length_runtime}!= 1 but no "
                     f"last kernel on stream {stream}, current kernel = {row}"
                 )
 
@@ -704,7 +704,7 @@ class CriticalPathAnalysis:
             rank (int): rank to analyze for the critical path.
             annotation (str): a trace annotation to limit the analysis to,
                 for example "ProfilerStep" would match all annotations that
-                match this string (ProfilerStep100, ProfilerStep101 etc)
+                match this string (ProfilerStep#100, ProfilerStep#101 etc)
             instance_id: can be either of the following
                 (int) - specify which instance of the annotation to consider.
                         Defaults to the first instance.

--- a/hta/analyzers/critical_path_analysis.py
+++ b/hta/analyzers/critical_path_analysis.py
@@ -476,7 +476,7 @@ class CPGraph(nx.DiGraph):
         last_node: Dict[int, CPNode] = {}
 
         # Scheduled a GPU-GPU sync on a stream
-        #  map from source kernel event ID -> event ID of kernel to sync on
+        #  map from dest kernel event ID -> event ID of kernel to sync on
         kernel_sync: Dict[int, int] = {}
 
         def handle_cuda_sync(row):

--- a/hta/analyzers/critical_path_analysis.py
+++ b/hta/analyzers/critical_path_analysis.py
@@ -771,7 +771,7 @@ class CriticalPathAnalysis:
                 for event in raw_events
                 if (
                     event["ph"] != "X"
-                    or event.get("cat", "") in ["user_annotation"]
+                    or event.get("cat", "") in ["user_annotation", "python_function"]
                     or ("args" in event and event["args"].get("critical", 0) == 1)
                 )
             ]

--- a/hta/common/trace.py
+++ b/hta/common/trace.py
@@ -118,10 +118,10 @@ class TraceSymbolTable:
     def get_runtime_launch_events_query(self) -> str:
         """Returns a SQL query you can pass to trace dataframe query()
         to filter events that are CUDA runtime kernel and memcpy launches."""
-        cudaLaunchKernel_id = self.sym_index.get("cudaLaunchKernel", None)
-        cudaLaunchKernelExC_id = self.sym_index.get("cudaLaunchKernelExC", None)
-        cudaMemcpyAsync_id = self.sym_index.get("cudaMemcpyAsync", None)
-        cudaMemsetAsync_id = self.sym_index.get("cudaMemsetAsync", None)
+        cudaLaunchKernel_id = self.sym_index.get("cudaLaunchKernel", -128)
+        cudaLaunchKernelExC_id = self.sym_index.get("cudaLaunchKernelExC", -128)
+        cudaMemcpyAsync_id = self.sym_index.get("cudaMemcpyAsync", -128)
+        cudaMemsetAsync_id = self.sym_index.get("cudaMemsetAsync", -128)
 
         return (
             f"((name == {cudaMemsetAsync_id}) or (name == {cudaMemcpyAsync_id}) or "

--- a/hta/common/trace.py
+++ b/hta/common/trace.py
@@ -120,13 +120,14 @@ class TraceSymbolTable:
         to filter events that are CUDA runtime kernel and memcpy launches."""
         cudaLaunchKernel_id = self.sym_index.get("cudaLaunchKernel", -128)
         cudaLaunchKernelExC_id = self.sym_index.get("cudaLaunchKernelExC", -128)
+        cuLaunchKernel_id = self.sym_index.get("cuLaunchKernel", -128)
         cudaMemcpyAsync_id = self.sym_index.get("cudaMemcpyAsync", -128)
         cudaMemsetAsync_id = self.sym_index.get("cudaMemsetAsync", -128)
 
         return (
             f"((name == {cudaMemsetAsync_id}) or (name == {cudaMemcpyAsync_id}) or "
-            f" (name == {cudaLaunchKernel_id}) or (name == {cudaLaunchKernelExC_id}))"
-            "and (index_correlation > 0)"
+            f" (name == {cudaLaunchKernel_id}) or (name == {cudaLaunchKernelExC_id})"
+            f" or (name == {cuLaunchKernel_id})) and (index_correlation > 0)"
         )
 
 

--- a/hta/common/trace.py
+++ b/hta/common/trace.py
@@ -109,7 +109,10 @@ class TraceSymbolTable:
 
     def is_cuda_runtime(self, trace_df: pd.dataframe, idx: int) -> bool:
         """Check if an event is a CUDA runtime event"""
-        return trace_df["cat"].loc[idx] == self.sym_index["cuda_runtime"]
+        return trace_df["cat"].loc[idx] == self.sym_index["cuda_runtime"] or (
+            "cuda_driver" in self.sym_index.keys()
+            and (trace_df["cat"].loc[idx] == self.sym_index["cuda_driver"])
+        )
 
     def is_operator(self, trace_df: pd.dataframe, idx: int) -> bool:
         """Check if an event is a CPU operator"""

--- a/hta/common/trace.py
+++ b/hta/common/trace.py
@@ -321,7 +321,8 @@ def add_iteration(df: pd.DataFrame, symbol_table: TraceSymbolTable) -> pd.DataFr
     """
     s_map = pd.Series(symbol_table.sym_index)
     s_tab = pd.Series(symbol_table.sym_table)
-    profiler_step_ids = s_map[s_map.index.str.startswith("ProfilerStep")]
+    # FIXME figure out how to add back profiler step annotation
+    profiler_step_ids = s_map[s_map.index.str.startswith("ProfilersdfsdfStep")]
     profiler_step_ids.sort_index()
 
     def _extract_iter(profiler_step_name: int) -> int:
@@ -694,7 +695,8 @@ class Trace:
         Filter out GPU kernels that are not launched by the CPU kernels in the traced iterations.
         """
         sym_index = self.symbol_table.get_sym_id_map()
-        profiler_steps = [v for k, v in sym_index.items() if "ProfilerStep" in k]
+        # FIXME Profiler steps
+        profiler_steps = [v for k, v in sym_index.items() if "ProfilerStepsdfdsf" in k]
 
         def filter_gpu_kernels_for_one_rank(trace_df: pd.DataFrame) -> pd.DataFrame:
             cpu_kernels = trace_df[trace_df["stream"].eq(-1)]

--- a/hta/common/trace.py
+++ b/hta/common/trace.py
@@ -322,8 +322,7 @@ def add_iteration(df: pd.DataFrame, symbol_table: TraceSymbolTable) -> pd.DataFr
     """
     s_map = pd.Series(symbol_table.sym_index)
     s_tab = pd.Series(symbol_table.sym_table)
-    # FIXME figure out how to add back profiler step annotation
-    profiler_step_ids = s_map[s_map.index.str.startswith("ProfilersdfsdfStep")]
+    profiler_step_ids = s_map[s_map.index.str.startswith("ProfilerStep")]
     profiler_step_ids.sort_index()
 
     def _extract_iter(profiler_step_name: int) -> int:
@@ -696,8 +695,7 @@ class Trace:
         Filter out GPU kernels that are not launched by the CPU kernels in the traced iterations.
         """
         sym_index = self.symbol_table.get_sym_id_map()
-        # FIXME Profiler steps
-        profiler_steps = [v for k, v in sym_index.items() if "ProfilerStepsdfdsf" in k]
+        profiler_steps = [v for k, v in sym_index.items() if "ProfilerStep" in k]
 
         def filter_gpu_kernels_for_one_rank(trace_df: pd.DataFrame) -> pd.DataFrame:
             cpu_kernels = trace_df[trace_df["stream"].eq(-1)]

--- a/hta/trace_analysis.py
+++ b/hta/trace_analysis.py
@@ -527,7 +527,7 @@ class TraceAnalysis:
             rank (int): rank to analyze for the critical path.
             annotation (str): a trace annotation to limit the analysis to,
                 for example "ProfilerStep" would match all annotations that
-                match this string (ProfilerStep100, ProfilerStep101 etc)
+                match this string (ProfilerStep#100, ProfilerStep#101 etc)
             instance_id: can be either of the following
                 (int) - specify which instance of the annotation to consider.
                         Defaults to the first instance.

--- a/hta/trace_analysis.py
+++ b/hta/trace_analysis.py
@@ -520,15 +520,20 @@ class TraceAnalysis:
         This will include GPU kernels launched by the cpu operators in that
         time duration.
         For example, you can use this to limit the analysis to one iteration
-        by passing annotation='ProfilerStep500'. See notes for how to pick the iteration.
+        by passing annotation='ProfilerStep'. See notes for how to pick the iteration.
 
         Args:
             t (Trace): Input trace data structure.
             rank (int): rank to analyze for the critical path.
             annotation (str): a trace annotation to limit the analysis to,
-                such as "ProfilerStep500"
-            instance_id (int): optionally specify which instance of the annotation
-                to consider. Defaults to the first instance.
+                for example "ProfilerStep" would match all annotations that
+                match this string (ProfilerStep100, ProfilerStep101 etc)
+            instance_id: can be either of the following
+                (int) - specify which instance of the annotation to consider. 
+                        Defaults to the first instance.
+                (Tuple(int, int)) - considers a range of annotation instances start to end,
+                        inclusive of both start and end instance.
+
 
         Returns: Tuple[CPGraph, bool] a pair of CPGraph object and a success or
             fail boolean value. True indicates that the critical path analysis

--- a/hta/trace_analysis.py
+++ b/hta/trace_analysis.py
@@ -4,7 +4,7 @@
 
 from collections import defaultdict
 from enum import auto, Flag
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
 
@@ -510,7 +510,7 @@ class TraceAnalysis:
         self,
         rank: int,
         annotation: str,
-        instance_id: Optional[int],
+        instance_id: Union[Optional[int], Tuple[int, int]],
     ) -> Tuple[CPGraph, bool]:
         r"""
         Perform critical path analysis for trace events within a rank.

--- a/hta/trace_analysis.py
+++ b/hta/trace_analysis.py
@@ -529,7 +529,7 @@ class TraceAnalysis:
                 for example "ProfilerStep" would match all annotations that
                 match this string (ProfilerStep100, ProfilerStep101 etc)
             instance_id: can be either of the following
-                (int) - specify which instance of the annotation to consider. 
+                (int) - specify which instance of the annotation to consider.
                         Defaults to the first instance.
                 (Tuple(int, int)) - considers a range of annotation instances start to end,
                         inclusive of both start and end instance.

--- a/tests/test_trace_analysis.py
+++ b/tests/test_trace_analysis.py
@@ -524,7 +524,8 @@ class TraceAnalysisTestCase(unittest.TestCase):
                 events_to_check = [
                     e
                     for e in trace_events
-                    if e["ph"] == "X" and e.get("cat", "") not in ["user_annotation"]
+                    if e["ph"] == "X"
+                    and e.get("cat", "") not in ["user_annotation", "python_function"]
                 ]
                 num_events_to_check = len(events_to_check)
                 marked_critical_events = sum(


### PR DESCRIPTION
## What does this PR do?
Includes several updates to the critical path analysis feature.
**Selecting region of interest**
* Enable matching a string for the user annotation, and specify a range. Thus we can analyze 2 or more iterations in the trace by passing `ProfilerStep` as the annotation.
* Improve filtering of gpu kernels to only include events that have a correlation edge to the CPU side.

**Queue Length**
* The queue length is used to determine if kernel launches are in critical path. Queue length was erroring out in the partial trace used in the analysis. Updated it to use the full trace to determine queue length. (See `t_full` and `_get_queue_length_time_series_for_rank()` in the PR.

**Stream Wait Event Synchronization (GPU->GPU)**
* Turned out that Stream Wait Events can happen out of order with when the actual kernel that syncs on the other stream executes.
* Added new logic that considers each `cudaStreamWaitEvent()` call on the CPU and finds the closest CPU kernel launch that occurs on the same CPU thread and runs on the CUDA stream the wait event was called on. 
* see `_get_cuda_stream_wait_event_df()`

**Misc**
* Support `cuLaunchKernel` driver events (this also improved trace_counters.py analyzer)
* Reduce noisy errors and add debugging information on asserts or failures.
* Documentation update.

## Tests
TestPlan:

Ran on two large production traces. Fairly complex GPU-GPU inter stream syncs take place and are mostly handled well by the algorithm now
![Screenshot 2023-10-20 at 11 46 25 AM](https://github.com/facebookresearch/HolisticTraceAnalysis/assets/6922212/b83356cd-85f0-4d4c-a456-0075a0acd67a)

Example cuLaunchKernel was correctly being supported
![Screenshot 2023-10-20 at 12 13 11 PM](https://github.com/facebookresearch/HolisticTraceAnalysis/assets/6922212/c3143e6a-311d-4059-ba11-d4a6d2a9d12c)


## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A - docs coming in a follow up
- [ ] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [ ] N/A
