### PR TITLE
Add `include_last_profiler_step` option to include the last profiler step

### DIFF
--- a/hta/common/trace.py
+++ b/hta/common/trace.py
@@ -706,7 +706,7 @@ class Trace:
             last_profiler_start = cpu_kernels[cpu_kernels["name"].isin(profiler_steps)][
                 "ts"
             ].max()
-            cpu_kernels = cpu_kernels[cpu_kernels["ts"] < last_profiler_start]
+            cpu_kernels = cpu_kernels[cpu_kernels["ts"] <= last_profiler_start]
             filtered_gpu_kernels = gpu_kernels.merge(
                 cpu_kernels["correlation"], on="correlation", how="inner"
             )

--- a/hta/common/trace.py
+++ b/hta/common/trace.py
@@ -451,12 +451,12 @@ class Trace:
             logger.debug(f"trace_files[{rank}] = {trace_file}")
         self.is_parsed = False
 
-    def load_traces(self) -> None:
+    def load_traces(self, include_last_profiler_step: Optional[bool] = False) -> None:
         if self.is_parsed:
             logger.warning("Traces are already parsed and loaded!")
             return
         self.parse_traces()
-        self.align_and_filter_trace()
+        self.align_and_filter_trace(include_last_profiler_step)
         for rank, trace_df in self.traces.items():
             df = self.traces[rank].set_index("index", drop=False)
             df.index.names = [None]
@@ -590,12 +590,12 @@ class Trace:
             f"leaving {sys._getframe().f_code.co_name} duration={t1 - t0:.2f} seconds"
         )
 
-    def align_and_filter_trace(self):
+    def align_and_filter_trace(self, include_last_profiler_step: Optional[bool] = False) -> None:
         """
         Align the starting time across multiple ranks and filter events that belong to incomplete iterations.
         """
         self._align_all_ranks()
-        self._filter_irrelevant_gpu_kernels()
+        self._filter_irrelevant_gpu_kernels(include_last_profiler_step)
 
     def get_trace(self, rank: int) -> pd.DataFrame:
         """
@@ -693,7 +693,7 @@ class Trace:
             trace_df["ts"] = trace_df["ts"] - self.min_ts
             self.traces[rank] = trace_df
 
-    def _filter_irrelevant_gpu_kernels(self) -> None:
+    def _filter_irrelevant_gpu_kernels(self, include_last_profiler_step: Optional[bool] = False) -> None:
         """
         Filter out GPU kernels that are not launched by the CPU kernels in the traced iterations.
         """
@@ -706,7 +706,10 @@ class Trace:
             last_profiler_start = cpu_kernels[cpu_kernels["name"].isin(profiler_steps)][
                 "ts"
             ].max()
-            cpu_kernels = cpu_kernels[cpu_kernels["ts"] <= last_profiler_start]
+            if include_last_profiler_step:
+                cpu_kernels = cpu_kernels[cpu_kernels["ts"] <= last_profiler_start]
+            else:
+                cpu_kernels = cpu_kernels[cpu_kernels["ts"] < last_profiler_start]
             filtered_gpu_kernels = gpu_kernels.merge(
                 cpu_kernels["correlation"], on="correlation", how="inner"
             )

--- a/hta/common/trace.py
+++ b/hta/common/trace.py
@@ -590,7 +590,9 @@ class Trace:
             f"leaving {sys._getframe().f_code.co_name} duration={t1 - t0:.2f} seconds"
         )
 
-    def align_and_filter_trace(self, include_last_profiler_step: Optional[bool] = False) -> None:
+    def align_and_filter_trace(
+        self, include_last_profiler_step: Optional[bool] = False
+    ) -> None:
         """
         Align the starting time across multiple ranks and filter events that belong to incomplete iterations.
         """
@@ -693,7 +695,9 @@ class Trace:
             trace_df["ts"] = trace_df["ts"] - self.min_ts
             self.traces[rank] = trace_df
 
-    def _filter_irrelevant_gpu_kernels(self, include_last_profiler_step: Optional[bool] = False) -> None:
+    def _filter_irrelevant_gpu_kernels(
+        self, include_last_profiler_step: Optional[bool] = False
+    ) -> None:
         """
         Filter out GPU kernels that are not launched by the CPU kernels in the traced iterations.
         """

--- a/hta/trace_analysis.py
+++ b/hta/trace_analysis.py
@@ -31,7 +31,7 @@ class TraceAnalysis:
         self,
         trace_files: Optional[Dict[int, str]] = None,
         trace_dir: str = DEFAULT_TRACE_DIR,
-        include_last_profiler_step: Optional[bool] = False
+        include_last_profiler_step: Optional[bool] = False,
     ):
         self.t = Trace(trace_files, trace_dir)
         self.t.load_traces(include_last_profiler_step)

--- a/hta/trace_analysis.py
+++ b/hta/trace_analysis.py
@@ -31,9 +31,10 @@ class TraceAnalysis:
         self,
         trace_files: Optional[Dict[int, str]] = None,
         trace_dir: str = DEFAULT_TRACE_DIR,
+        include_last_profiler_step: Optional[bool] = False
     ):
         self.t = Trace(trace_files, trace_dir)
-        self.t.load_traces()
+        self.t.load_traces(include_last_profiler_step)
         assert self.t.is_parsed is True
 
     def get_comm_comp_overlap(self, visualize: bool = True) -> pd.DataFrame:

--- a/tests/test_trace_analysis.py
+++ b/tests/test_trace_analysis.py
@@ -21,7 +21,6 @@ from hta.trace_analysis import TimeSeriesTypes, TraceAnalysis
 
 class TraceAnalysisTestCase(unittest.TestCase):
     vision_transformer_t: TraceAnalysis
-    vision_transformer_include_last_profiler_step_t: TraceAnalysis
     inference_t: TraceAnalysis
     df_index_resolver_t: TraceAnalysis
     rank_non_gpu_t: TraceAnalysis
@@ -35,9 +34,6 @@ class TraceAnalysisTestCase(unittest.TestCase):
         rank_non_gpu_trace_dir: str = "tests/data/rank_non_gpu/"
         h100_trace_dir: str = "tests/data/h100"
         cls.vision_transformer_t = TraceAnalysis(trace_dir=vision_transformer_trace_dir)
-        cls.vision_transformer_include_last_profiler_step_t = TraceAnalysis(
-            trace_dir=vision_transformer_trace_dir, include_last_profiler_step=True
-        )
         cls.inference_t = TraceAnalysis(trace_dir=inference_trace_dir)
         cls.df_index_resolver_t = TraceAnalysis(trace_dir=df_index_resolver_trace_dir)
         cls.rank_non_gpu_t = TraceAnalysis(trace_dir=rank_non_gpu_trace_dir)
@@ -131,13 +127,6 @@ class TraceAnalysisTestCase(unittest.TestCase):
         results = self.vision_transformer_t.get_profiler_steps()
         expected = [15, 16, 17, 18]
         self.assertListEqual(results, expected)
-        results_include_last_profiler_step = (
-            self.vision_transformer_include_last_profiler_step_t.get_profiler_steps()
-        )
-        expected_include_last_profiler_step = [15, 16, 17, 18, 19]
-        self.assertListEqual(
-            results_include_last_profiler_step, expected_include_last_profiler_step
-        )
 
     def test_get_potential_stragglers(self):
         TCase = namedtuple(

--- a/tests/test_trace_analysis.py
+++ b/tests/test_trace_analysis.py
@@ -21,7 +21,6 @@ from hta.trace_analysis import TimeSeriesTypes, TraceAnalysis
 
 class TraceAnalysisTestCase(unittest.TestCase):
     vision_transformer_t: TraceAnalysis
-    vision_transformer_include_last_profiler_step_t: TraceAnalysis
     inference_t: TraceAnalysis
     df_index_resolver_t: TraceAnalysis
     rank_non_gpu_t: TraceAnalysis
@@ -35,9 +34,6 @@ class TraceAnalysisTestCase(unittest.TestCase):
         rank_non_gpu_trace_dir: str = "tests/data/rank_non_gpu/"
         h100_trace_dir: str = "tests/data/h100"
         cls.vision_transformer_t = TraceAnalysis(trace_dir=vision_transformer_trace_dir)
-        cls.vision_transformer_include_last_profiler_step_t = TraceAnalysis(
-            trace_dir=vision_transformer_trace_dir, include_last_profiler_step=True
-        )
         cls.inference_t = TraceAnalysis(trace_dir=inference_trace_dir)
         cls.df_index_resolver_t = TraceAnalysis(trace_dir=df_index_resolver_trace_dir)
         cls.rank_non_gpu_t = TraceAnalysis(trace_dir=rank_non_gpu_trace_dir)
@@ -133,8 +129,12 @@ class TraceAnalysisTestCase(unittest.TestCase):
         self.assertListEqual(results, expected)
 
     def test_include_last_profiler_step(self):
+        vision_transformer_trace_dir = self.vision_transformer_t.t.trace_path
+        vision_transformer_include_last_profiler_step_t = TraceAnalysis(
+            trace_dir=vision_transformer_trace_dir, include_last_profiler_step=True
+        )
         results_include_last_profiler_step = (
-            self.vision_transformer_include_last_profiler_step_t.get_profiler_steps()
+            vision_transformer_include_last_profiler_step_t.get_profiler_steps()
         )
         expected_results = [15, 16, 17, 18, 19]
         self.assertListEqual(results_include_last_profiler_step, expected_results)

--- a/tests/test_trace_analysis.py
+++ b/tests/test_trace_analysis.py
@@ -21,6 +21,7 @@ from hta.trace_analysis import TimeSeriesTypes, TraceAnalysis
 
 class TraceAnalysisTestCase(unittest.TestCase):
     vision_transformer_t: TraceAnalysis
+    vision_transformer_include_last_profiler_step_t: TraceAnalysis
     inference_t: TraceAnalysis
     df_index_resolver_t: TraceAnalysis
     rank_non_gpu_t: TraceAnalysis
@@ -34,6 +35,9 @@ class TraceAnalysisTestCase(unittest.TestCase):
         rank_non_gpu_trace_dir: str = "tests/data/rank_non_gpu/"
         h100_trace_dir: str = "tests/data/h100"
         cls.vision_transformer_t = TraceAnalysis(trace_dir=vision_transformer_trace_dir)
+        cls.vision_transformer_include_last_profiler_step_t = TraceAnalysis(
+            trace_dir=vision_transformer_trace_dir, include_last_profiler_step=True
+        )
         cls.inference_t = TraceAnalysis(trace_dir=inference_trace_dir)
         cls.df_index_resolver_t = TraceAnalysis(trace_dir=df_index_resolver_trace_dir)
         cls.rank_non_gpu_t = TraceAnalysis(trace_dir=rank_non_gpu_trace_dir)
@@ -127,6 +131,13 @@ class TraceAnalysisTestCase(unittest.TestCase):
         results = self.vision_transformer_t.get_profiler_steps()
         expected = [15, 16, 17, 18]
         self.assertListEqual(results, expected)
+
+    def test_include_last_profiler_step(self):
+        results_include_last_profiler_step = (
+            self.vision_transformer_include_last_profiler_step_t.get_profiler_steps()
+        )
+        expected_results = [15, 16, 17, 18, 19]
+        self.assertListEqual(results_include_last_profiler_step, expected_results)
 
     def test_get_potential_stragglers(self):
         TCase = namedtuple(

--- a/tests/test_trace_analysis.py
+++ b/tests/test_trace_analysis.py
@@ -21,6 +21,7 @@ from hta.trace_analysis import TimeSeriesTypes, TraceAnalysis
 
 class TraceAnalysisTestCase(unittest.TestCase):
     vision_transformer_t: TraceAnalysis
+    vision_transformer_include_last_profiler_step_t: TraceAnalysis
     inference_t: TraceAnalysis
     df_index_resolver_t: TraceAnalysis
     rank_non_gpu_t: TraceAnalysis
@@ -34,6 +35,8 @@ class TraceAnalysisTestCase(unittest.TestCase):
         rank_non_gpu_trace_dir: str = "tests/data/rank_non_gpu/"
         h100_trace_dir: str = "tests/data/h100"
         cls.vision_transformer_t = TraceAnalysis(trace_dir=vision_transformer_trace_dir)
+        cls.vision_transformer_include_last_profiler_step_t = TraceAnalysis(
+            trace_dir=vision_transformer_trace_dir, include_last_profiler_step=True)
         cls.inference_t = TraceAnalysis(trace_dir=inference_trace_dir)
         cls.df_index_resolver_t = TraceAnalysis(trace_dir=df_index_resolver_trace_dir)
         cls.rank_non_gpu_t = TraceAnalysis(trace_dir=rank_non_gpu_trace_dir)
@@ -127,6 +130,9 @@ class TraceAnalysisTestCase(unittest.TestCase):
         results = self.vision_transformer_t.get_profiler_steps()
         expected = [15, 16, 17, 18]
         self.assertListEqual(results, expected)
+        results_include_last_profiler_step = self.vision_transformer_include_last_profiler_step_t.get_profiler_steps()
+        expected_include_last_profiler_step = [15, 16, 17, 18, 19]
+        self.assertListEqual(results_include_last_profiler_step, expected_include_last_profiler_step)
 
     def test_get_potential_stragglers(self):
         TCase = namedtuple(

--- a/tests/test_trace_analysis.py
+++ b/tests/test_trace_analysis.py
@@ -36,7 +36,8 @@ class TraceAnalysisTestCase(unittest.TestCase):
         h100_trace_dir: str = "tests/data/h100"
         cls.vision_transformer_t = TraceAnalysis(trace_dir=vision_transformer_trace_dir)
         cls.vision_transformer_include_last_profiler_step_t = TraceAnalysis(
-            trace_dir=vision_transformer_trace_dir, include_last_profiler_step=True)
+            trace_dir=vision_transformer_trace_dir, include_last_profiler_step=True
+        )
         cls.inference_t = TraceAnalysis(trace_dir=inference_trace_dir)
         cls.df_index_resolver_t = TraceAnalysis(trace_dir=df_index_resolver_trace_dir)
         cls.rank_non_gpu_t = TraceAnalysis(trace_dir=rank_non_gpu_trace_dir)
@@ -130,9 +131,13 @@ class TraceAnalysisTestCase(unittest.TestCase):
         results = self.vision_transformer_t.get_profiler_steps()
         expected = [15, 16, 17, 18]
         self.assertListEqual(results, expected)
-        results_include_last_profiler_step = self.vision_transformer_include_last_profiler_step_t.get_profiler_steps()
+        results_include_last_profiler_step = (
+            self.vision_transformer_include_last_profiler_step_t.get_profiler_steps()
+        )
         expected_include_last_profiler_step = [15, 16, 17, 18, 19]
-        self.assertListEqual(results_include_last_profiler_step, expected_include_last_profiler_step)
+        self.assertListEqual(
+            results_include_last_profiler_step, expected_include_last_profiler_step
+        )
 
     def test_get_potential_stragglers(self):
         TCase = namedtuple(


### PR DESCRIPTION
## What does this PR do?
Fixes #76 , see also #77 . This is a new PR initiated based on the branch from the cloned repo instead of from the forked repo.

When parsing the trace files, originally it was intentional that the last profiler step is not included because of some traces events in the last profiler step might be cut off during the trace collection. This PR adds `include_last_profiler_step` option to the `TraceAnalysis` class to allow users to switch on and off based on their needs.

## Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [x] N/A
