### PR TITLE
[critical path] Update critical path edge set computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 #### Fixed
 - Fixed issue #65 to handle floating point counter values in cupti\_counter\_analysis.
+- Fixec bug in Critical path analysis relating to listing out the edges on the critical path.
 
 ## [0.2.0] - 2023-05-22
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 #### Fixed
 - Fixed issue #65 to handle floating point counter values in cupti\_counter\_analysis.
-- Fixec bug in Critical path analysis relating to listing out the edges on the critical path.
+- Fixes bug in Critical path analysis relating to listing out the edges on the critical path.
 
 ## [0.2.0] - 2023-05-22
 #### Added

--- a/hta/analyzers/critical_path_analysis.py
+++ b/hta/analyzers/critical_path_analysis.py
@@ -676,15 +676,23 @@ class CPGraph(nx.DiGraph):
             self.node_list[nid].ev_idx for nid in self.critical_path_nodes
         }
 
-        critical_path_nodes_set = set(self.critical_path_nodes)
-
         # Reset critical_path_edges_set across invocations
         self.critical_path_edges_set = set()
-        for u, v in self.edges:
-            e = self.edges[u, v]["object"]
-            if u in critical_path_nodes_set and v in critical_path_nodes_set:
-                self.critical_path_edges_set.add(e)
 
+        # Add edges connecting the nodes along the critical path
+        niter = iter(self.critical_path_nodes)
+        u = next(niter)
+
+        while 1:
+            try:
+                v = next(niter)
+                e = self.edges[u, v]["object"]
+                self.critical_path_edges_set.add(e)
+                u = v
+            except StopIteration:
+                break
+
+        assert len(self.critical_path_edges_set) == (len(self.critical_path_nodes) - 1)
         return True
 
     def show_critical_path(self) -> None:


### PR DESCRIPTION
## What does this PR do?
Fixes a bug in listing out the edges on the critical path.

### Details
Previously, after getting the ordered list of nodes on a critical path I was looking up all edges that had a src and dest in this list
```
for u, v in self.edges:
            e = self.edges[u, v]["object"]
            if u in critical_path_nodes_set and v in critical_path_nodes_set:   # <<< See here
                  self.critical_path_edges_set.add(e)
```

This is incorrect as pointed out by one of the users. We should only consider edges for nodes along the path itself.
For example, say the critical path node list is = [2, 6, 9, 10]. We should only include edges 2->6, 6->9 and 9->10. Previous logic was looking up any edges (u,v) with u,v belonging to [2, 6, 9, 10]. 

## Test
```
 pip install -e .; 
 python3 -m unittest -v tests.test_critical_path_analysis.CriticalPathAnalysisTestCase
```

## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [x] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [ ] N/A
