### PR TITLE
[critical path] add basic edge attribution to events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 #### Fixed
 - Fixed issue #65 to handle floating point counter values in cupti\_counter\_analysis.
 - Fixes bug in Critical path analysis relating to listing out the edges on the critical path.
+- Updated critical path analysis with edge attribution.
 
 ## [0.2.0] - 2023-05-22
 #### Added


### PR DESCRIPTION
## What does this PR do?
Adding the ability to attribute an edge in the critical path graph to events. For kernels this is simple,
but for nested operators on CPU we follow an approach outlined in the code.
- Adds a function 'get_event_attribution_for_edge()' as a quick helper to look up the result.
- Adds a reverse lookup function 'get_edges_attributed_to_event()'
- Update unit tests to check new invariant and previous attirbution

## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [x] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [ ] N/A

## Test plan
Test Plan:

Updated unit test
`pip install -e .; python3 -m unittest -v tests.test_critical_path_analysis.CriticalPathAnalysisTestCase`

Use prints below to validate results

```
=Op depth = 0 last_node=None
=Entering node aten::conv2d, id = 279.0
=Op depth = 1 last_node=CPNode(event: 279.0, node_id=2, ts=40898643, is_start=True)
==Entering node aten::convolution, id = 280.0
Attributing edge between nodes 2 -> 4 to event id = 279.0, event_name = aten::conv2d
```
When entering the stack we correctly attribute it to the left side or src event like conv2d here

```
==Op depth = 2 last_node=CPNode(event: 280.0, node_id=4, ts=40898656, is_start=True)
===Entering node aten::_convolution, id = 281.0
Attributing edge between nodes 4 -> 6 to event id = 280.0, event_name = aten::convolution
===Op depth = 3 last_node=CPNode(event: 281.0, node_id=6, ts=40898691, is_start=True)
====Entering node aten::cudnn_convolution, id = 282.0
Attributing edge between nodes 6 -> 8 to event id = 281.0, event_name = aten::_convolution
====Op depth = 4 last_node=CPNode(event: 282.0, node_id=8, ts=40898741, is_start=True)
=====Entering node cudaStreamIsCapturing, id = 979.0
Attributing edge between nodes 8 -> 10 to event id = 282.0, event_name = aten::cudnn_convolution
```
Same as above

```
=====Op depth = 5 last_node=CPNode(event: 979.0, node_id=10, ts=40898766, is_start=True)
=====Exiting node cudaStreamIsCapturing, id = 979.0
Attributing edge between nodes 10 -> 11 to event id = 979.0, event_name = cudaStreamIsCapturing
```
Correctly attributing the leaf level operator cudaStreamIsCapturing.

```
=====Op depth = 4 last_node=CPNode(event: 979.0, node_id=11, ts=40898770.0, is_start=False)
=====Entering node cudaMalloc, id = 981.0
Attributing edge between nodes 11 -> 12 to event id = 282.0, event_name = aten::cudnn_convolution
```
The above edge is embedded within parent operator as it connects end of one nested op (cudaStreamIsCapturing) to the start of another nested op (cudaMalloc). The algorithm is correctly attributing it to the parent op 'cudnn_convolution'.

Lastly we can see the attribution being correct for unwinding of the stack
```
====Exiting node aten::add_, id = 285.0
Attributing edge between nodes 31 -> 29 to event id = 285.0, event_name = aten::add_
====Op depth = 3 last_node=CPNode(event: 285.0, node_id=29, ts=40915867.0, is_start=False)
===Exiting node aten::_convolution, id = 281.0
Attributing edge between nodes 29 -> 7 to event id = 281.0, event_name = aten::_convolution
===Op depth = 2 last_node=CPNode(event: 281.0, node_id=7, ts=40915891.0, is_start=False)
==Exiting node aten::convolution, id = 280.0
Attributing edge between nodes 7 -> 5 to event id = 280.0, event_name = aten::convolution
==Op depth = 1 last_node=CPNode(event: 280.0, node_id=5, ts=40916099.0, is_start=False)
=Exiting node aten::conv2d, id = 279.0
Attributing edge between nodes 5 -> 3 to event id = 279.0, event_name = aten::conv2d
```