### PR TITLE
Adds pytest support for circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,11 +71,12 @@ install_dev_requirements: &install_dev_requirements
 
 # This is an alias to run all unit tests possible on a platform.
 run_unittests: &run_unittests
- - run:
+  - run:
       name: Run all unit tests
       # We run all and not stopping on failure on CPU since docker time is cheaper.
       command: |
-        python3 -m unittest -v
+        mkdir test-results
+        pytest --junitxml=test-results/junit.xml tests
 
 run_unittests_with_coverage: &run_unittests_with_coverage
   - run:
@@ -136,6 +137,8 @@ jobs:
           key: cache-key-cpu-py38-{{.Environment.CACHE_VERSION}}-{{checksum "setup.py"}}-{{checksum "requirements.txt"}}
 
       - <<: *run_unittests
+      - store_test_results:
+          path: test-results
 
 
   cpu_tests_py39:
@@ -160,6 +163,8 @@ jobs:
           key: cache-key-cpu-py39-{{.Environment.CACHE_VERSION}}-{{checksum "setup.py"}}-{{checksum "requirements.txt"}}
 
       - <<: *run_unittests
+      - store_test_results:
+          path: test-results
 
   cpu_tests_py310:
     <<: *cpu_py310
@@ -183,6 +188,8 @@ jobs:
           key: cache-key-cpu-py310-{{.Environment.CACHE_VERSION}}-{{checksum "setup.py"}}-{{checksum "requirements.txt"}}
 
       - <<: *run_unittests
+      - store_test_results:
+          path: test-results
 
   cpu_tests_py311:
     <<: *cpu_py311
@@ -206,6 +213,8 @@ jobs:
           key: cache-key-cpu-py311-{{.Environment.CACHE_VERSION}}-{{checksum "setup.py"}}-{{checksum "requirements.txt"}}
 
       - <<: *run_unittests
+      - store_test_results:
+          path: test-results
 
 # -------------------------------------------------------------------------------------
 # Workflows to run

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,8 @@ __To run the entire test suite__
 
 ```
 python3 -m unittest -v
+# OR using pytest
+pytest tests
 ```
 
 __To run a specific test__
@@ -80,7 +82,14 @@ in the `CallStackTestCase` class in `test_call_stack.py`, use the following comm
 
 ```
 python3 -m unittest -v tests.test_call_stack.CallStackTestCase.test_sort_events
+# OR using pytest
+pytest tests -k test_sort_events
+# OR using pytest with the exact file
+pytest tests/test_call_stack.py -k test_sort_events
 ```
+
+Note, all our tests are written using `unittest` module, so use of pytest is primarily for a better
+test runner and support in the CI.
 
 ### CircleCI status
 The build status on the `main` branch is visible on the repository homepage. CircleCI status

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ networkx>=3.1
 pandas>=1.5.2
 plotly>=5.11.0
 pydot>=1.3.0  # required by third_party/param/
+pytest>=7.4.4
 black==22.8.0
 usort==1.0.4
 coverage>=7.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ networkx>=3.1
 pandas>=1.5.2
 plotly>=5.11.0
 pydot>=1.3.0  # required by third_party/param/
+pytest>=7.4.4


### PR DESCRIPTION
## What does this PR do?
Circle CI can track individual tests, however it does not support the simple unittest runner. So we can use PyTest for this.

The PyTest natively supports unittest based tests. Essentially, it acts like a test runner and provides some great features like stdout/stderr caputring, better tracebacks, test selection and more. See [](https://docs.pytest.org/en/7.1.x/how-to/unittest.html). The main motivation however is to enabled Circle CI and we can easily track down flaky tests and observer the test history.

Summary of changes
* Add pytest to requirements[dev].txt
* Update CirclecI config to dump test results and upload them to circle CI.
* Updated documentation to show alternative commands using pytest package.

## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [ ] Did you write any new necessary tests?
  - [x] N/A
- [x] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [x] N/A
