### PR TITLE
Critical Path Add 0 weight causal edges for kernel launches

### DIFF
--- a/hta/trace_analysis.py
+++ b/hta/trace_analysis.py
@@ -582,6 +582,13 @@ class TraceAnalysis:
         Returns: the overlaid trace file path. The generated trace file will
         have a prefix of "overlaid_critical_path\_" in its name compared
         to the original trace file.
+
+        Note: In case of kernel launches that are not on the critical path the graph
+        still has a 0 weight edge between CUDA runtime and kernel. These 0 weight
+        edges are not shown in the overlaid trace by default. Set the environment
+        variable CRITICAL_PATH_SHOW_ZERO_WEIGHT_LAUNCH_EDGE=1 to enable adding this
+        to the overlaid trace. Add this to your notebook
+        `os.environ["CRITICAL_PATH_SHOW_ZERO_WEIGHT_LAUNCH_EDGE"] = 1`
         """
         return CriticalPathAnalysis.overlay_critical_path_analysis(
             self.t,


### PR DESCRIPTION
## What does this PR do?
When we modify the CPGraph for performance simulations, we do not want GPU kernels to start before their CPU launch counterparts. To prevent this we always add a 0 weight edge for runtime launch -> kernel the launch delay is not in critical path.
Details
* Add a helper to add launch edges.
* Include 0 weight edges whenever launch edges are not added.
* Handle overlaying these edges.

### note for overlaid trace
Displaying these edges is disabled in overlaid trace to avoid confusing users :) The environment variable CRITICAL_PATH_SHOW_ZERO_WEIGHT_LAUNCH_EDGE=1 will help you enable it.

## Test notebook
We can see for the simple add example we have
All the launch edges are now shown
![Screenshot 2024-02-22 at 11 16 09 AM](https://github.com/facebookresearch/HolisticTraceAnalysis/assets/6922212/6b479407-02f9-4689-ae4e-21773396a34a)

You can see for this epilogues kernel, there is a 0 weight edge
![Screenshot 2024-02-22 at 11 16 19 AM](https://github.com/facebookresearch/HolisticTraceAnalysis/assets/6922212/b035ef86-30e8-43e0-a6c8-20155240223c)
While we have a kernel-kernel edge
![Screenshot 2024-02-22 at 11 16 42 AM](https://github.com/facebookresearch/HolisticTraceAnalysis/assets/6922212/cb6e50ab-e41f-4cce-9656-71d29881b7fc)

Critical path is not impacted as shown
![Screenshot 2024-02-22 at 11 17 05 AM](https://github.com/facebookresearch/HolisticTraceAnalysis/assets/6922212/36c5656f-4c50-4e20-a6dc-583e4a405465)

## Unit test
Unit tests are also working and validating critical path.

## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [x] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [ ] N/A
