### PR TITLE
add knob to turn off causal edges

### DIFF
--- a/tests/test_critical_path_analysis.py
+++ b/tests/test_critical_path_analysis.py
@@ -17,6 +17,7 @@ from hta.trace_analysis import TraceAnalysis
 
 class CriticalPathAnalysisTestCase(unittest.TestCase):
     def setUp(self):
+        os.environ["CRITICAL_PATH_ADD_ZERO_WEIGHT_LAUNCH_EDGE"] = "1"
         self.base_data_dir = str(Path(__file__).parent.parent.joinpath("tests/data"))
         critical_path_trace_dir: str = os.path.join(
             self.base_data_dir, "critical_path/simple_add"
@@ -154,6 +155,7 @@ class CriticalPathAnalysisTestCase(unittest.TestCase):
                 type=CPEdgeType.KERNEL_KERNEL_DELAY,
             ),
         )
+
         # also check for 0 duration causal launch edge
         ampere_runtime_idx = trace_df.index_correlation.loc[ampere_kernel_idx]
         r2start, _ = cp_graph.get_nodes_for_event(ampere_runtime_idx)


### PR DESCRIPTION
## What does this PR do?
Seeing some issues with 0 weight edges added recently. While these are being debugged turn these off for the time being.
A new environment variable can control this behavior - use this in noteboooks
`os.environ["CRITICAL_PATH_ADD_ZERO_WEIGHT_LAUNCH_EDGE"] = "1"`

## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [x] N/A
