### PR TITLE
update is_comm_kernel check to work with newer nccl versions (and thus generate expected comm/compute overlap numbers)

### DIFF
--- a/hta/utils/utils.py
+++ b/hta/utils/utils.py
@@ -60,7 +60,7 @@ def is_comm_kernel(name: str) -> bool:
     Returns:
         A boolean indicating if the kernel is a communication kernel.
     """
-    return "ncclKernel" in name
+    return "ncclKernel" in name or "ncclDev" in name
 
 
 def is_memory_kernel(name: str) -> bool:


### PR DESCRIPTION
## What does this PR do?
This PR fixes a common error hit with newer versions of Nccl. 
Most traces currently break on computing the comm/compute overlap numbers b/c it does not account for the kernel name being prefaced with 'ncclDev' instead of only 'ncclKernel'.  

The error is 
~~~
Runtime Warning: invalid value encountered in scalar divide return (shifted_overlap["time_y"] - shifted_overlap["time_x"].sum())
~~~

The fix is simple, check for both to get the proper comm/compute overlap numbers in hta utility function "is comm kernel".

## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [ ] N/A
