### PR TITLE
Trace load and json parsing optimizations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,12 @@ install_repo: &install_repo
       command: |
         pip install .
 
+install_ijson: &install_ijson
+  - run:
+      name: Install ijson
+      command: |
+        pip install ijson==3.2.3
+
 install_dev_requirements: &install_dev_requirements
   - run:
       name: Install development packages
@@ -99,6 +105,7 @@ jobs:
       - <<: *init_submodules
       - <<: *setup_venv
       - <<: *install_repo
+      - <<: *install_ijson
       - <<: *install_dev_requirements
 
       # Cache the venv directory that contains dependencies
@@ -125,6 +132,7 @@ jobs:
       - <<: *init_submodules
       - <<: *setup_venv
       - <<: *install_repo
+      - <<: *install_ijson
 
       # Cache the venv directory that contains dependencies
       - restore_cache:
@@ -140,7 +148,7 @@ jobs:
       - store_test_results:
           path: test-results
 
-
+# -- note ijson parser tests run on py3.8 version.
   cpu_tests_py39:
     <<: *cpu_py39
 

--- a/benchmarks/trace_load_benchmark.py
+++ b/benchmarks/trace_load_benchmark.py
@@ -7,15 +7,25 @@ import logging
 
 import pyperf
 
-from hta.common.trace import Trace
+from hta.common.trace import parse_trace_file, Trace
+from hta.common.trace_parser import set_default_trace_parsing_backend
+
 from hta.configs.config import logger
+from hta.configs.parser_config import ParserBackend
 
 _TRACE_DIRS = ["vision_transformer", "inference_single_rank"]
 TRACE_DIRS = [f"tests/data/{d}" for d in _TRACE_DIRS]
 
+TRACE_FILES = [
+    "tests/data/vision_transformer/rank-1.json.gz",
+    # ADD SOME BIG FILE HERE
+    # "../../load_benchmarks/python_func_ops_example/rank-1.Jan_17_19_32_44.5411.pt.trace.json.gz",
+]
+
 # For large number of iterations this makes the logs more readable,
 # feel free to change this.
-logger.setLevel(logging.ERROR)
+# logger.setLevel(logging.ERROR)
+logger.setLevel(logging.INFO)
 
 
 def load_and_parse_trace(
@@ -35,7 +45,31 @@ def load_and_parse_trace(
     return pyperf.perf_counter() - t0
 
 
+def load_and_parse_trace_file(loops: int, filename: str, backend: ParserBackend):
+    """Runs trace load and parsing for a single rank. This helps measure
+    and optimize the json load / dataframe construction code path.
+    """
+    set_default_trace_parsing_backend(backend)
+    range_it = range(loops)
+    t0 = pyperf.perf_counter()
+    for _ in range_it:
+        parse_trace_file(filename)
+    return pyperf.perf_counter() - t0
+
+
 runner = pyperf.Runner()
+
+# Run different parser backends to identify performance and memory overhead
+for trace_file in TRACE_FILES:
+    for backend in ParserBackend:
+        runner.bench_time_func(
+            f"parse[{backend}:{trace_file}]",
+            load_and_parse_trace_file,
+            trace_file,
+            backend,
+            inner_loops=1,
+        )
+
 for trace_dir in TRACE_DIRS:
     runner.bench_time_func(
         f"parse[{trace_dir}]", load_and_parse_trace, trace_dir, inner_loops=1

--- a/hta/analyzers/critical_path_analysis.py
+++ b/hta/analyzers/critical_path_analysis.py
@@ -23,7 +23,8 @@ from hta.analyzers.trace_counters import TraceCounters
 # from hta.common.trace_call_graph import CallGraph, CallStackGraph, DeviceType
 from hta.common.call_stack import CallGraph, CallStackGraph, DeviceType
 
-from hta.common.trace import decode_symbol_id_to_symbol_name, Trace
+from hta.common.trace import Trace
+from hta.common.trace_symbol_table import decode_symbol_id_to_symbol_name
 from hta.configs.config import logger
 from hta.utils.utils import is_comm_kernel
 

--- a/hta/analyzers/straggler.py
+++ b/hta/analyzers/straggler.py
@@ -9,7 +9,8 @@ import pandas as pd
 import plotly.express as px
 
 from hta.analyzers.timeline import _get_unique_values, plot_timeline_gpu_kernels
-from hta.common.trace import Trace, TraceSymbolTable
+from hta.common.trace import Trace
+from hta.common.trace_symbol_table import TraceSymbolTable
 
 
 def extract_iteration_info(trace: Trace) -> pd.DataFrame:

--- a/hta/analyzers/timeline.py
+++ b/hta/analyzers/timeline.py
@@ -9,7 +9,8 @@ from typing import List, Optional
 import pandas as pd
 import plotly.express as px
 
-from hta.common.trace import Trace, TraceSymbolTable
+from hta.common.trace import Trace
+from hta.common.trace_symbol_table import TraceSymbolTable
 from hta.configs.config import logger
 
 

--- a/hta/common/timeline.py
+++ b/hta/common/timeline.py
@@ -5,13 +5,13 @@ from typing import List, Optional, Set
 
 import pandas as pd
 import plotly.express as px
-
-from hta.common.trace import TraceSymbolTable
 from hta.common.trace_df import (
     find_events_by_name_patterns_using_decoded_names,
     find_events_by_name_patterns_using_symbol_table,
 )
 from hta.common.trace_filter import Filter
+
+from hta.common.trace_symbol_table import TraceSymbolTable
 from hta.configs.config import logger
 from plotly.io import to_html
 

--- a/hta/common/trace_call_graph.py
+++ b/hta/common/trace_call_graph.py
@@ -3,8 +3,9 @@ from typing import Dict, Generator, List, Optional
 
 import pandas as pd
 
-from hta.common.trace import get_cpu_gpu_correlation, Trace, TraceSymbolTable
+from hta.common.trace import get_cpu_gpu_correlation, Trace
 from hta.common.trace_call_stack import CallStackGraph, CallStackIdentity, CallStackNode
+from hta.common.trace_symbol_table import TraceSymbolTable
 from hta.common.types import DeviceType, infer_device_type
 from hta.configs.config import logger
 

--- a/hta/common/trace_call_stack.py
+++ b/hta/common/trace_call_stack.py
@@ -7,7 +7,7 @@ from typing import Callable, Dict, List, NamedTuple, Optional
 import numpy as np
 import pandas as pd
 
-from hta.common.trace import TraceSymbolTable
+from hta.common.trace_symbol_table import TraceSymbolTable
 from hta.common.types import DeviceType, infer_device_type
 from hta.configs.config import logger
 

--- a/hta/common/trace_df.py
+++ b/hta/common/trace_df.py
@@ -2,7 +2,7 @@ from typing import List, Tuple
 
 import pandas as pd
 
-from hta.common.trace import TraceSymbolTable
+from hta.common.trace_symbol_table import TraceSymbolTable
 
 
 def get_iterations(df: pd.DataFrame) -> List[int]:

--- a/hta/common/trace_filter.py
+++ b/hta/common/trace_filter.py
@@ -3,7 +3,8 @@ from typing import List, Optional, Tuple, Union
 
 import pandas as pd
 
-from hta.common.trace import logger, TraceSymbolTable
+from hta.common.trace import logger
+from hta.common.trace_symbol_table import TraceSymbolTable
 from hta.utils.utils import get_symbol_column_names
 
 

--- a/hta/common/trace_parser.py
+++ b/hta/common/trace_parser.py
@@ -1,0 +1,430 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import gzip
+import json
+import math
+import os
+import time
+import tracemalloc
+from typing import Any, Dict, Optional, Tuple
+
+import numpy as np
+
+import pandas as pd
+from hta.common.trace_symbol_table import TraceSymbolTable
+
+from hta.configs.config import logger
+from hta.configs.parser_config import (
+    AttributeSpec,
+    ParserBackend,
+    ParserConfig,
+    ValueType,
+)
+
+# from memory_profiler import profile
+
+MetaData = Dict[str, Any]
+_TRACE_PARSING_BACKEND: Optional[ParserBackend] = None
+
+IJSON_INSTRS = """ Install ijson with pip by using
+  pip install ijson
+
+Also please install yajl for optimal speed. You will need an installation of yajl (C++ library) for your system, followed by the python bindings.
+  conda install anaconda::yajl  # or system install of yajl without conda
+  pip install yajl-py==2.1.2
+
+Check the backend with: python3 -c "import ijson; print(ijson.backend)" output = yajl2_c
+For more details see https://pypi.org/project/ijson/#performance-tips, https://anaconda.org/anaconda/yajl, https://pypi.org/project/yajl/"""
+
+
+def _auto_detect_parser_backend() -> ParserBackend:
+    """Finds optimal parser backend and returns it"""
+    try:
+        import ijson
+    except ModuleNotFoundError:
+        logger.warning("Trace parsing can be sped up by using ijson." + IJSON_INSTRS)
+        return ParserBackend.JSON
+
+    if "yajl" not in ijson.backend:
+        logger.warning(
+            f"Current ijson backend {ijson.backend} does not use 'yajl'."
+            "The ijson parser will be much slower as it uses python"
+            "Reverting to simple json parser!\n"
+            "Consider instructions-" + IJSON_INSTRS
+        )
+        return ParserBackend.JSON
+
+    # Use the best ijson backend
+    return ParserBackend.IJSON_BATCH_AND_COMPRESS
+
+
+def set_default_trace_parsing_backend(parser_backend: ParserBackend):
+    """Set the default trace parser backend"""
+    global _TRACE_PARSING_BACKEND
+    _TRACE_PARSING_BACKEND = parser_backend
+
+
+def get_default_trace_parsing_backend() -> ParserBackend:
+    """Get the default trace parser backend"""
+    global _TRACE_PARSING_BACKEND
+    if _TRACE_PARSING_BACKEND is None:
+        # TODO: This will be updated in a future release
+        # _TRACE_PARSING_BACKEND = _auto_detect_parser_backend()
+        _TRACE_PARSING_BACKEND = ParserBackend.JSON
+    return _TRACE_PARSING_BACKEND
+
+
+# @profile
+def parse_trace_dict(trace_file_path: str) -> Dict[str, Any]:
+    """
+    Parse a raw trace file into a dictionary.
+
+    Args:
+        trace_file_path (str) : the path to a trace file.
+
+    Returns:
+        A dictionary representation of the trace.
+    """
+    t_start = time.perf_counter()
+    trace_record: Dict[str, Any] = {}
+    if trace_file_path.endswith(".gz"):
+        with gzip.open(trace_file_path, "rb") as fh:
+            trace_record = json.loads(fh.read())
+    elif trace_file_path.endswith(".json"):
+        with open(trace_file_path, "r") as fh2:
+            trace_record = json.loads(fh2.read())
+    else:
+        raise ValueError(
+            f"expect the value of trace_file ({trace_file_path}) ends with '.gz' or 'json'"
+        )
+    t_end = time.perf_counter()
+    logger.warning(f"Parsed {trace_file_path} time = {(t_end - t_start):.2f} seconds ")
+    return trace_record
+
+
+# @profile
+def _parse_trace_events_ijson(trace_file_path: str) -> pd.DataFrame:
+    """
+    Parse the trace file using iterative json.
+
+    Args:
+        trace_file_path (str) : the path to a trace file.
+
+    Returns:
+        pd.DataFrame: parsed trace dataframe.
+    """
+    import ijson
+
+    logger.info(f"Parsing using ijson (ijson backend = {ijson.backend})")
+
+    t_start = time.perf_counter()
+    with (
+        gzip.open(trace_file_path, "rb")
+        if trace_file_path.endswith(".gz")
+        else open(trace_file_path, "rb")
+    ) as fh:
+
+        iterator = ijson.items(fh, "traceEvents.item", use_float=True)
+
+        # Ignore python function tracer
+        # TODO make this filter configuration in ParserConfig
+        df = pd.DataFrame(e for e in iterator if e.get("cat") != "python_function")
+
+    t_end = time.perf_counter()
+    logger.warning(
+        f"Parsed (ijson) {trace_file_path} time = {(t_end - t_start):.2f} seconds "
+    )
+    return df
+
+
+def _parse_trace_events_ijson_batched(
+    trace_file_path: str, cfg: ParserConfig, compress_on_fly: bool = False
+) -> pd.DataFrame:
+    """
+    Parse the trace file using iterative json in batches.
+
+    Args:
+        trace_file_path (str): the path to a trace file.
+        compress_on_fly (bool): parse "args" on the fly.
+
+    Returns:
+        pd.DataFrame: parsed trace dataframe.
+    """
+    import ijson
+
+    logger.info(f"Parsing using ijson (ijson backend = {ijson.backend})")
+
+    arg_name_map = {arg.raw_name: arg.name for arg in cfg.get_args()}
+    args_to_keep = arg_name_map.keys()
+    logger.debug(f"arg_name_map = {arg_name_map}")
+
+    def trim_event(e):
+        if "args" not in e:
+            return e
+        for arg, val in e["args"].items():
+            if arg in args_to_keep:
+                e[arg_name_map[arg]] = val
+            elif e.get("cat", "") == "cuda_profiler_range":
+                e[arg] = val
+        e.pop("args", None)
+        return e
+
+    df = pd.DataFrame()
+
+    t_start = time.perf_counter()
+    with (
+        gzip.open(trace_file_path, "rb")
+        if trace_file_path.endswith(".gz")
+        else open(trace_file_path, "rb")
+    ) as fh:
+        # TODO make events to skip configurable in ParserConfig
+        iterator = (
+            e
+            for e in ijson.items(fh, "traceEvents.item", use_float=True)
+            if e.get("cat") != "python_function"
+        )
+        if compress_on_fly:
+            iterator = (trim_event(e) for e in iterator)
+
+        # XXX Currently using 1000 as batch size.
+        batch_size = 1000
+        batch = []
+        dfs = []
+
+        # Iterate over filtered dictionaries and append to DataFrame in batches
+        for item in iterator:
+            batch.append(item)
+            if len(batch) == batch_size:
+                dfs.append(pd.DataFrame(batch))
+                batch = []
+
+        # Append remaining items if any
+        if batch:
+            dfs.append(pd.DataFrame(batch))
+
+        df = pd.concat(dfs, ignore_index=True)
+
+        # Fill args if not populated
+        arg_default_map = {arg.name: arg.default_value for arg in cfg.get_args()}
+        trace_args_cols = set(arg_default_map.keys()).intersection(set(df.columns))
+        for arg_col in trace_args_cols:
+            df[arg_col].fillna(arg_default_map[arg_col], inplace=True)
+
+        missing_cols = set(arg_default_map.keys()).difference(set(df.columns))
+        for arg_col in missing_cols:
+            df[arg_col] = arg_default_map[arg_col]
+
+    t_end = time.perf_counter()
+    logger.warning(
+        f"Parsed (ijson) {trace_file_path} time = {(t_end - t_start):.2f} seconds "
+    )
+    return df
+
+
+def _compress_df(
+    df: pd.DataFrame, cfg: Optional[ParserConfig] = None
+) -> Tuple[pd.DataFrame, TraceSymbolTable]:
+    """
+    Compress a Dataframe to reduce its memory footprint.
+
+    Args:
+        df (pd.DataFrame): the input DataFrame
+        cfg (Optional[ParserConfig]): an object to customize how to parse/compress the trace.
+
+    Returns:
+        Tuple[pd.DataFrame, TraceSymbolTable]
+            The first item is the compressed dataframe.
+            The second item is the local symbol table specific to this dataframe.
+    """
+    cfg = cfg or ParserConfig.get_default_cfg()
+
+    # drop rows with null values
+    df.dropna(axis=0, subset=["dur", "cat"], inplace=True)
+    df.drop(df[df["cat"] == "Trace"].index, inplace=True)
+
+    # drop columns
+    columns_to_drop = {"ph", "id", "bp", "s"}.intersection(set(df.columns))
+    df.drop(list(columns_to_drop), axis=1, inplace=True)
+    columns = set(df.columns)
+
+    # performance counters appear as args
+    if "args" in columns and "cuda_profiler_range" in df.cat.unique():
+        counter_names = set.union(
+            *[set(d.keys()) for d in df[df.cat == "cuda_profiler_range"]["args"].values]
+        )
+        # args_to_keep = args_to_keep.union(counter_names)
+        cfg.add_args(
+            [AttributeSpec(name, name, ValueType.Int, -1) for name in counter_names]
+        )
+        logger.info(f"counter_names={counter_names}")
+        logger.info(f"args={cfg.get_args()}")
+
+    if "args" in columns:
+        args_to_keep = cfg.get_args()
+        for arg in args_to_keep:
+            df[arg.name] = df["args"].apply(
+                lambda row, arg=arg: (
+                    row.get(arg.raw_name, arg.default_value)
+                    if isinstance(row, dict)
+                    else arg.default_value
+                )
+            )
+        df.drop(["args"], axis=1, inplace=True)
+
+    # create a local symbol table
+    local_symbol_table = TraceSymbolTable()
+    symbols = set(df["cat"].unique()).union(set(df["name"].unique()))
+    local_symbol_table.add_symbols(symbols)
+
+    sym_index = local_symbol_table.get_sym_id_map()
+    for col in ["cat", "name"]:
+        df[col] = df[col].apply(lambda s: sym_index[s])
+
+    # data type downcast
+    for col in df.columns:
+        if df[col].dtype.kind == "i":
+            df[col] = pd.to_numeric(df[col], errors="coerce", downcast="integer")
+
+    return df, local_symbol_table
+
+
+# @profile
+def _parse_trace_dataframe_json(
+    trace_file_path: str, cfg: ParserConfig
+) -> Tuple[MetaData, pd.DataFrame, TraceSymbolTable]:
+    """
+    Parse the trace file into dataframe.
+
+    Args:
+        trace_file_path (str) : the path to a trace file.
+
+    Returns:
+        pd.DataFrame: parsed trace dataframe.
+    """
+    trace_record = parse_trace_dict(trace_file_path)
+    meta: Dict[str, Any] = {k: v for k, v in trace_record.items() if k != "traceEvents"}
+    df: pd.DataFrame = pd.DataFrame()
+    local_symbol_table: TraceSymbolTable = TraceSymbolTable()
+    if "traceEvents" in trace_record:
+        df = pd.DataFrame(trace_record["traceEvents"])
+        if df["ts"].dtype == np.dtype("float64"):
+            logger.warning(
+                f"Rounding down ns resolution events due to issue with events overlapping."
+                f" ts dtype = {df['ts'].dtype}, dur dtype = {df['dur'].dtype}."
+                f"Please see https://github.com/pytorch/pytorch/pull/122425"
+            )
+            # Don't floor directly, first find the end
+            df["end"] = df["ts"] + df["dur"]
+
+            df["ts"] = df[~df["ts"].isnull()]["ts"].apply(lambda x: math.ceil(x))
+            df["end"] = df[~df["end"].isnull()]["end"].apply(lambda x: math.floor(x))
+            df["dur"] = df["end"] - df["ts"]
+
+        # assign an index to each event
+        df.reset_index(inplace=True)
+        df["index"] = pd.to_numeric(df["index"], downcast="integer")
+
+        df, local_symbol_table = _compress_df(df, cfg)
+
+    return meta, df, local_symbol_table
+
+
+# @profile
+def _parse_trace_dataframe_ijson(
+    trace_file_path: str,
+    cfg: ParserConfig,
+    batched: bool = False,
+    compress_on_fly: bool = False,
+) -> Tuple[MetaData, pd.DataFrame, TraceSymbolTable]:
+    """
+    Parse the trace file using iterative json, supports multiple modes below.
+
+    Args:
+        trace_file_path (str): the path to a trace file.
+        batched (bool): use batching
+        compress_on_fly (bool): parse "args" on the fly.
+
+    Returns:
+        pd.DataFrame: parsed trace dataframe.
+    """
+    meta: Dict[str, Any] = {}
+    # XXX handle adding metadata
+    # k: v for k, v in trace_record.items() if k != "traceEvents"}
+
+    if batched:
+        df = _parse_trace_events_ijson_batched(trace_file_path, cfg, compress_on_fly)
+    else:
+        df = _parse_trace_events_ijson(trace_file_path)
+
+    # assign an index to each event
+    df.reset_index(inplace=True)
+    df["index"] = pd.to_numeric(df["index"], downcast="integer")
+
+    df, local_symbol_table = _compress_df(df, cfg)
+    return meta, df, local_symbol_table
+
+
+def parse_trace_dataframe(
+    trace_file_path: str,
+    cfg: ParserConfig,
+) -> Tuple[MetaData, pd.DataFrame, TraceSymbolTable]:
+    """Parse a single trace file into a meat test_data dictionary and a dataframe of events.
+    Args:
+        trace_file_path (str): The path to a trace file. When the trace_file is a relative path.
+            This method combines the object's trace_path with trace_file to get the full path of the trace file.
+        cfg (ParserConfig, Optional): A ParserConfig object controls how to parse the trace file.
+    Returns:
+        Tuple[MetaData, pd.DataFrame, TraceSymbolTable]
+            The first item is the trace's metadata;
+            The second item is the dataframe representation of the trace's events.
+            The third item is the symbol table to encode the symbols of the trace.
+
+    Raises:
+        JSONDecodeError when the trace file is not a valid JSON document.
+        ValueError if parser config passes invalid parser backend.
+    """
+    trace_memory = cfg.trace_memory
+    parser_backend: ParserBackend
+    if cfg.parser_backend is None:
+        parser_backend = get_default_trace_parsing_backend()
+    else:
+        parser_backend = cfg.parser_backend
+
+    t_start = time.perf_counter()
+    if trace_memory:
+        tracemalloc.start()
+
+    if parser_backend == ParserBackend.JSON:
+        meta, df, local_symbol_table = _parse_trace_dataframe_json(trace_file_path, cfg)
+    elif parser_backend == ParserBackend.IJSON:
+        meta, df, local_symbol_table = _parse_trace_dataframe_ijson(
+            trace_file_path, cfg
+        )
+    elif parser_backend == ParserBackend.IJSON_BATCHED:
+        meta, df, local_symbol_table = _parse_trace_dataframe_ijson(
+            trace_file_path,
+            cfg,
+            batched=True,
+        )
+    elif parser_backend == ParserBackend.IJSON_BATCH_AND_COMPRESS:
+        meta, df, local_symbol_table = _parse_trace_dataframe_ijson(
+            trace_file_path, cfg, batched=True, compress_on_fly=True
+        )
+    else:
+        raise ValueError(f"unexpected or unsupported parser = {parser_backend}")
+
+    t_end = time.perf_counter()
+    logger.warning(
+        f"Parsed {trace_file_path} backend={parser_backend} in {(t_end - t_start):.2f} seconds; current PID:{os. getpid()}"
+    )
+    if trace_memory:
+        current, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        logger.warning(
+            f"Parser Memory usage peak = {(peak/1024/1024):.2f} MB, current = {(current/1024/1024):.2f} MB"
+        )
+    return meta, df, local_symbol_table

--- a/hta/common/trace_stack_filter.py
+++ b/hta/common/trace_stack_filter.py
@@ -2,10 +2,10 @@ from enum import Enum
 from typing import List, Optional
 
 import pandas as pd
-
-from hta.common.trace import TraceSymbolTable
 from hta.common.trace_df import find_op_occurrence
 from hta.common.trace_filter import Filter, FirstIterationFilter
+
+from hta.common.trace_symbol_table import TraceSymbolTable
 from hta.configs.config import logger
 from hta.utils.utils import get_symbol_column_names
 

--- a/hta/common/trace_symbol_table.py
+++ b/hta/common/trace_symbol_table.py
@@ -1,0 +1,162 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import multiprocessing as mp
+
+import queue
+from typing import Any, Dict, Iterable, List
+
+import pandas as pd
+
+from hta.utils.utils import shorten_name
+
+
+class _SymbolCollector:
+    """
+    To support a multiprocessing version of symbol table update, we use _SymbolCollector to a shared queue
+    to collect all the symbols and then use a single process to merge the results. A _SymbolCollector object
+    implements a function object so that it allow the multiple processes to share the data.
+    """
+
+    def __init__(self, q: queue.Queue[Any]):
+        self.queue = q
+
+    def __call__(self, symbols: Iterable[str]) -> None:
+        for s in symbols:
+            self.queue.put(s)
+
+
+# We use a TraceSymbolTable to store the bidirectional symbol<-->id mapping for each Trace object.
+# This table will be shared among all the ranks to encode/decode the symbols in their data frames.
+class TraceSymbolTable:
+    """
+    TraceSymbolTable stores the bidirectional symbol<-->id mapping for all traces.
+    Because of potential races caused by multiprocessing, we serialize updates to the
+    TraceSymbolTable using a synchronize.lock.
+
+    We assume all read operations to this table by a Trace object occur after it adds all its symbols.
+    Therefore, there is no need to lock the read access.
+
+    Attributes:
+        sym_table (List[str]) : a list of symbols.
+        sym_index (Dict[str, int]) : a map from symbol to ID.
+    """
+
+    def __init__(self):
+        self.sym_table: List[str] = []
+        self.sym_index: Dict[str, int] = {}
+
+    def add_symbols(self, symbols: Iterable[str]) -> None:
+        for s in symbols:
+            if s not in self.sym_index:
+                idx = len(self.sym_table)
+                self.sym_table.append(s)
+                self.sym_index[s] = idx
+
+    def add_symbols_mp(self, symbols_list: List[Iterable[str]]) -> None:
+        m = mp.Manager()
+        shared_queue: queue.Queue[Any] = m.Queue()
+        collector = _SymbolCollector(shared_queue)
+
+        with mp.get_context("spawn").Pool(
+            min(mp.cpu_count(), len(symbols_list))
+        ) as pool:
+            pool.map(collector, symbols_list)
+            pool.close()
+            pool.join()
+
+        all_symbols = []
+        while not shared_queue.empty():
+            all_symbols.append(shared_queue.get())
+        self.add_symbols(all_symbols)
+
+    def get_sym_id_map(self) -> Dict[str, int]:
+        return self.sym_index
+
+    def get_sym_table(self) -> List[str]:
+        return self.sym_table
+
+    def add_symbols_to_trace_df(self, trace_df: pd.DataFrame, col: str) -> None:
+        """
+        Take a trace dataframe and expand symbols in one of its columns.
+        Args:
+            trace_df (pd.DataFrame): Dataframe for trace from one rank.
+            col (str): column to expand symbols on.
+
+        Returns:
+            None
+        """
+        trace_df[col] = trace_df[col].apply(
+            lambda i: self.sym_table[i] if (0 <= i < len(self.sym_table)) else ""
+        )
+
+    @staticmethod
+    def create_symbol_table_from_df(df: pd.DataFrame) -> TraceSymbolTable:
+        """Create a symbol table from a DataFrame's cat and name columns.
+
+        Args:
+            df (pd.DataFrame): an input DataFrame.
+
+        Returns:
+            TraceSymbolTable: a symbol table containing all unique `name` and `cat` symbols in df.
+
+        Raise:
+            ValueError: when one of the follow two conditions happens:
+                (1) `df` doesn't have the `name` and `cat` columns; or
+                (2) they are not string type.
+        """
+        if (
+            ("name" in df.columns)
+            and (df.dtypes["name"] == "object")
+            and ("cat" in df.columns)
+            and (df.dtypes["cat"] == "object")
+        ):
+            symbols = set(df["cat"].unique()).union(set(df["name"].unique()))
+            symbol_table = TraceSymbolTable()
+            symbol_table.add_symbols(symbols)
+            return symbol_table
+        raise ValueError(
+            "Expect both name and cat columns of string types to be present in the dataframe"
+        )
+
+    def is_cuda_runtime(self, trace_df: pd.DataFrame, idx: int) -> bool:
+        """Check if an event is a CUDA runtime event"""
+        return trace_df["cat"].loc[idx] == self.sym_index["cuda_runtime"] or (
+            "cuda_driver" in self.sym_index.keys()
+            and (trace_df["cat"].loc[idx] == self.sym_index["cuda_driver"])
+        )
+
+    def is_operator(self, trace_df: pd.DataFrame, idx: int) -> bool:
+        """Check if an event is a CPU operator"""
+        return trace_df["cat"].loc[idx] == self.sym_index["cpu_op"]
+
+    def get_runtime_launch_events_query(self) -> str:
+        """Returns a SQL query you can pass to trace dataframe query()
+        to filter events that are CUDA runtime kernel and memcpy launches."""
+        cudaLaunchKernel_id = self.sym_index.get("cudaLaunchKernel", -128)
+        cudaLaunchKernelExC_id = self.sym_index.get("cudaLaunchKernelExC", -128)
+        cuLaunchKernel_id = self.sym_index.get("cuLaunchKernel", -128)
+        cudaMemcpyAsync_id = self.sym_index.get("cudaMemcpyAsync", -128)
+        cudaMemsetAsync_id = self.sym_index.get("cudaMemsetAsync", -128)
+
+        return (
+            f"((name == {cudaMemsetAsync_id}) or (name == {cudaMemcpyAsync_id}) or "
+            f" (name == {cudaLaunchKernel_id}) or (name == {cudaLaunchKernelExC_id})"
+            f" or (name == {cuLaunchKernel_id})) and (index_correlation > 0)"
+        )
+
+
+def decode_symbol_id_to_symbol_name(
+    df: pd.DataFrame, symbol_table: TraceSymbolTable, use_shorten_name: bool
+) -> None:
+    """Decode symbol ids into symbol names and write the decoded data into s_name and s_cat columns."""
+    s_tab: List[str] = symbol_table.sym_table
+    if use_shorten_name:
+        s_tab = [shorten_name(s) for s in s_tab]
+    if "name" in df.columns and df["name"].dtype.kind == "i":
+        df["s_name"] = df["name"].apply(lambda idx: s_tab[idx])
+    if "cat" in df.columns and df["cat"].dtype.kind == "i":
+        df["s_cat"] = df["cat"].apply(lambda idx: s_tab[idx])

--- a/tests/test_symbol_table.py
+++ b/tests/test_symbol_table.py
@@ -6,7 +6,7 @@ import multiprocessing as mp
 import unittest
 from typing import List, Set
 
-from hta.common.trace import TraceSymbolTable
+from hta.common.trace_symbol_table import TraceSymbolTable
 
 
 class SymbolDecoder:

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -21,9 +21,10 @@ from hta.common.timeline import (
     Timeline,
     TimelinePlotSetting,
 )
-from hta.common.trace import Trace, TraceSymbolTable
+from hta.common.trace import Trace
 from hta.common.trace_call_graph import CallGraph
 from hta.common.trace_filter import CPUOperatorFilter, GPUKernelFilter
+from hta.common.trace_symbol_table import TraceSymbolTable
 
 _MODULE = "hta.common.timeline"
 

--- a/tests/test_trace_call_stack.py
+++ b/tests/test_trace_call_stack.py
@@ -7,7 +7,6 @@ from typing import Dict, List
 import numpy as np
 
 import pandas as pd
-from hta.common.trace import TraceSymbolTable
 
 from hta.common.trace_call_stack import (
     _less_than,
@@ -16,6 +15,7 @@ from hta.common.trace_call_stack import (
     CallStackNode,
     sort_events,
 )
+from hta.common.trace_symbol_table import TraceSymbolTable
 
 
 class CallStackTestCase(unittest.TestCase):


### PR DESCRIPTION
## What does this PR do?

Trace loading is one of the slowest steps in analysis and consumes the highest memory with 25% traces having >2.7 millions events.
* We propose a solution to speed up trace load time of large trace(s) by 2.6x and more importantly reduce the peak memory usage by 8.5x.

**Why we can do better?**
* Overall trace loading for a large trace is taking 6 GBs of memory. But the json object only takes about 800 MB.
* For large traces a significant fraction of events are “python_function” related and are not used in trace analysis.
Following are results on a large trace
<img width="658" alt="Screenshot 2024-03-26 at 10 49 46 AM" src="https://github.com/facebookresearch/HolisticTraceAnalysis/assets/6922212/8efe7ffa-e75c-4a2f-8b9a-a4baa3517857">

### Proposed solution
* We leverage ijson to filter "python_function" events that are not used in analysis.
* Add on optimizations that use batching, and extracting the args on the fly. This removes most of the memory overhead

Caveat: ijson can use an optimized C based json parser (yajl), if available. The user should have this else python based parsing is much slower that simply using

### Code Details
1. Moved the symbol table and json parsing (trace_parser.py) into two different files.
2. Proposed a `parser_backend` option in `ParserCfg`.
3. Added ijson based parsing in trace_parser.py (main set of changes are here.
4. Added simple unit test for ijson based parsing.
5. Auto-detect best backend (this is not used right now to keep json backend as default)

## Testing

### Unit test
* `pytest tests/test_symbol_table.py`
* `pytest tests/test_trace_parse.py -k TraceParseIjson`
* `pytest tests` 

Checking automatic detection of backend.

### Benchmarking results

Run
`python3 benchmarks/trace_load_benchmark.py -v -p 1 -l 1`
```
parse[json:tests/data/vision_transformer/rank-1.json.gz]: Mean +- std dev: 6.53 sec +- 0.36 sec
parse[ijson:tests/data/vision_transformer/rank-1.json.gz]: Mean +- std dev: 7.57 sec +- 0.02 sec
parse[ijson_batched:tests/data/vision_transformer/rank-1.json.gz]: Mean +- std dev: 7.89 sec +- 0.24 sec
parse[ijson_batch_and_compress:tests/data/vision_transformer/rank-1.json.gz]: Mean +- std dev: 5.70 sec +- 0.21 sec
parse[json:../../load_benchmarks/python_func_ops_example/rank-1.Jan_17_19_32_44.5411.pt.trace.json.gz]: Mean +- std dev: 96.5 sec +- 1.6 sec
parse[ijson:../../load_benchmarks/python_func_ops_example/rank-1.Jan_17_19_32_44.5411.pt.trace.json.gz]: Mean +- std dev: 45.5 sec +- 0.4 sec
parse[ijson_batched:../../load_benchmarks/python_func_ops_example/rank-1.Jan_17_19_32_44.5411.pt.trace.json.gz]: Mean +- std dev: 47.1 sec +- 0.4 sec
parse[ijson_batch_and_compress:../../load_benchmarks/python_func_ops_example/rank-1.Jan_17_19_32_44.5411.pt.trace.json.gz]: Mean +- std dev: 36.8 sec +- 0.6 sec
(hta) bcoutinho@bcoutinho-mbp HolisticTraceAnalysis2 % z
```
Full output 
https://gist.github.com/briancoutinho/d179890c464161a1f9fe8e56f90aae9c
  

## Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [ ] N/A
