### PR TITLE
Fixing Unary Op evaluate issue

### DIFF
--- a/hta/analyzers/critical_path_analysis.py
+++ b/hta/analyzers/critical_path_analysis.py
@@ -464,7 +464,8 @@ class CPGraph(nx.DiGraph):
 
         def _previous_launch(ts: int, pid: int, tid: int) -> Optional[int]:
             """Find the previous CUDA launch on same pid and tid"""
-            df = runtime_calls.query(f"pid == {pid} and tid == {tid}")
+            pid_match_df = runtime_calls[runtime_calls.pid == pid]
+            df = pid_match_df[pid_match_df.tid == tid]
             lower_neighbors = df[df["ts"] < ts]["ts"]
             return lower_neighbors.idxmax() if len(lower_neighbors) else None
 


### PR DESCRIPTION
Summary:
Without this diff, the critical_path_analysis on some traces fails with the error: `'UnaryOp' object has no attribute 'evaluate'`

This is apparently a pandas bug: https://github.com/pandas-dev/pandas/issues/16363, which has been solved a few times, but appears in different forms time, and again. 

Reframing the query is solving the problem in critical_path_analysis for the time being.

Differential Revision: D54828775


