### PR TITLE
[1/n] Optimize performance Critical Path Analysis algorithm for CUDA sync events

### DIFF
--- a/hta/analyzers/breakdown_analysis.py
+++ b/hta/analyzers/breakdown_analysis.py
@@ -253,9 +253,12 @@ class BreakdownAnalysis:
                         if u_running not in running_mapping:
                             running_mapping[u_running] = k_t
                         else:
+                            # FIXME linter mismatch between fbcode and git T183519933
+                            # fmt: off
                             running_mapping[u_running] = (
                                 f"{running_mapping[u_running]} overlapping {k_t}"
                             )
+                            # fmt: on
 
         overlap_kernel_type_df["kernel_type"] = ""
         overlap_kernel_type_df = overlap_kernel_type_df[
@@ -296,9 +299,12 @@ class BreakdownAnalysis:
         if gpu_kernel_time.shape[0] > num_kernels:
             gpu_kernel_time["cumsum"] = gpu_kernel_time["sum"].cumsum()
             quantiles = gpu_kernel_time["cumsum"].quantile(duration_ratio)
+            # FIXME linter mismatch between fbcode and git T183519933
+            # fmt: off
             gpu_kernel_time.loc[gpu_kernel_time["cumsum"] > quantiles, "name"] = (
                 "others"
             )
+            # fmt: on
             gpu_kernel_time.loc[gpu_kernel_time.index >= num_kernels, "name"] = "others"
             gpu_kernel_time = gpu_kernel_time.groupby(by=["name"])["sum"].agg(
                 ["sum", "max", "min", "mean", "std"]
@@ -464,9 +470,12 @@ class BreakdownAnalysis:
         is_kernel_kernel_delay = ~is_host_wait & (
             gpu_kernels_s["idle_interval"] < consecutive_kernel_delay
         )
+        # FIXME linter mismatch between fbcode and git T183519933
+        # fmt: off
         gpu_kernels_s.loc[is_kernel_kernel_delay, "idle_category"] = (
             IdleTimeType.KERNEL_WAIT.value
         )
+        # fmt: on
 
         gpu_kernels_groupby = gpu_kernels_s.groupby("idle_category")
         if show_idle_interval_stats:

--- a/hta/analyzers/critical_path_analysis.py
+++ b/hta/analyzers/critical_path_analysis.py
@@ -588,6 +588,7 @@ class CPGraph(nx.DiGraph):
         cuda_record_calls.rename(
             columns={"index_launch_event": "index_previous_launch"}, inplace=True
         )
+        cuda_record_calls.index_previous_launch.fillna(-1, inplace=True)
 
         return cuda_record_calls
 
@@ -763,6 +764,7 @@ class CPGraph(nx.DiGraph):
         cuda_stream_wait_events.rename(
             columns={"index_launch_event": "index_next_launch"}, inplace=True
         )
+        cuda_stream_wait_events.index_next_launch.fillna(-1, inplace=True)
 
         return cuda_stream_wait_events.set_index("index")
 

--- a/hta/analyzers/critical_path_analysis.py
+++ b/hta/analyzers/critical_path_analysis.py
@@ -480,6 +480,39 @@ class CPGraph(nx.DiGraph):
 
         return cuda_record_calls
 
+    def _get_cuda_runtime_calls_df(self):
+        """Returns a dataframe of CUDA launch runtime calls and associated CUDA stream
+        The returned dataframe has addtional columns
+        * stream: for the CUDA stream the runtime event launched on
+        * launch id: is a sequential number for each kernel/memx launch. This is useful
+                     in CUDA event synchronization algorithms
+        """
+        gpu_kernels = self.full_trace_df.query("stream != -1 and index_correlation > 0")
+
+        runtime_calls = (
+            (
+                self.full_trace_df.query(
+                    self.symbol_table.get_runtime_launch_events_query()
+                )
+                .copy()
+                .sort_values(by="ts", axis=0)
+            )
+            .merge(
+                gpu_kernels[["stream", "index"]],
+                left_on="index_correlation",
+                right_on="index",
+                suffixes=["", "_kernel"],
+            )
+            .set_index("index")
+        )
+
+        # Give a sequential launch ID for every launch event
+        runtime_calls.reset_index(inplace=True)
+        runtime_calls["launch_id"] = runtime_calls.index
+        runtime_calls.set_index("index", inplace=True)
+
+        return runtime_calls
+
     def _get_cuda_event_record_df1(self) -> Optional[pd.DataFrame]:
         """For Event based synchronization we need to track the last
         kernel/memcpy launched on a CPU thread just before the cudaEventRecord
@@ -495,16 +528,7 @@ class CPGraph(nx.DiGraph):
         cudaEventRecord_id = sym_index.get("cudaEventRecord")
 
         # CUDA launch runtime calls
-        runtime_calls: pd.DataFrame = (
-            self.full_trace_df.query(
-                self.symbol_table.get_runtime_launch_events_query()
-            )
-            .copy()
-            .sort_values(by="ts", axis=0)
-        )
-        # Give a sequential launch ID for every launch event
-        runtime_calls.reset_index(inplace=True)
-        runtime_calls["launch_id"] = runtime_calls.index
+        runtime_calls = self._get_cuda_runtime_calls_df()
 
         # CUDA Record Event calls
         cuda_record_calls = (
@@ -529,7 +553,7 @@ class CPGraph(nx.DiGraph):
             comb_cuda_records = comb.loc[comb.name == cudaEventRecord_id].copy()
             comb_cuda_records.drop(axis=1, columns="launch_id", inplace=True)
 
-            # Now join the previous_launch_id to actually kernel launch events.
+            # Now join the previous_launch_id to actual kernel launch events.
             return pd.merge(
                 comb_cuda_records,
                 comb_launches[["launch_id", "index", "correlation"]],
@@ -541,16 +565,19 @@ class CPGraph(nx.DiGraph):
                 validate="many_to_one",
             )
 
+        pid_tids = cuda_record_calls[["pid", "tid"]].groupby(["pid", "tid"]).groups.keys()
+
         cuda_record_dfs = [
             find_previous_launch(pid, tid)
-            for (pid, tid) in cuda_record_calls[["pid", "tid"]]
-            .groupby(["pid", "tid"])
-            .groups.keys()
+            for (pid, tid) in pid_tids
         ]
-        cuda_record_calls = pd.concat(cuda_record_dfs, axis=0).sort_values(by="ts", axis=0)
+        cuda_record_calls = pd.concat(cuda_record_dfs, axis=0).sort_values(
+            by="ts", axis=0
+        )
 
-        # cleanup
-        cuda_record_calls.drop(axis=1, columns=["level_0", "index"], inplace=True)
+        # Cleanup
+        # cuda_record_calls.drop(axis=1, columns=["level_0", "index"], inplace=True)
+        # PS: you can comment the below if you need to debug any issue
         cuda_record_calls.drop(
             axis=1,
             columns=["launch_id", "previous_launch_id", "correlation_launch_event"],
@@ -597,9 +624,56 @@ class CPGraph(nx.DiGraph):
             )
             .set_index("index")
         )
-        # Give a sequential launch ID for every launch event
-        #runtime_calls.reset_index(inplace=True)
-        #runtime_calls["launch_id"] = runtime_calls.index
+
+        # CUDA stream wait event runtime calls and associated CUDA stream
+        cudaStreamWaitEvent_id = sym_index.get("cudaStreamWaitEvent")
+        cuda_stream_wait_events = (
+            self.full_trace_df.query(
+                f"name == {cudaStreamWaitEvent_id} and index_correlation > 0"
+            )[["index", "ts", "pid", "tid", "correlation", "index_correlation"]]
+            .copy()
+            .sort_values(by="ts", axis=0)
+        ).merge(
+            gpu_kernels[["stream", "index"]],
+            left_on="index_correlation",
+            right_on="index",
+            suffixes=["", "_kernel"],
+        )
+
+        def _next_launch(ts: int, pid: int, tid: int, stream: int) -> int:
+            """Find the next CUDA launch on same pid, tid and stream"""
+            df = runtime_calls.query(
+                f"pid == {pid} and tid == {tid} and stream == {stream}"
+            )
+            upper_neighbors = df[df["ts"] > ts]["ts"]
+            return upper_neighbors.idxmin() if len(upper_neighbors) else -1
+
+        cuda_stream_wait_events["index_next_launch"] = cuda_stream_wait_events.apply(
+            lambda x: _next_launch(x["ts"], x["pid"], x["tid"], x["stream"]), axis=1
+        )
+
+        return cuda_stream_wait_events.set_index("index")
+
+    def _get_cuda_stream_wait_event_df1(self) -> Optional[pd.DataFrame]:
+        """For Event based synchronization we need to track the next
+        kernel/memcpy launched on a CPU thread just after cudaStreamWaitEvent
+
+        This function returns a dataframe of cudaStreamWaitEvent events,
+        and includes an additional column 'index_next_launch'
+        that specifies the closest CUDA kernel launch on the same CPU thread
+        and associated CUDA stream.
+        """
+        sym_index = self.symbol_table.get_sym_id_map()
+        if (
+            "cudaStreamWaitEvent" not in sym_index
+            or "Stream Wait Event" not in sym_index
+        ):
+            return None
+
+        # CUDA launch runtime calls
+        runtime_calls = self._get_cuda_runtime_calls_df()
+
+        gpu_kernels = self.full_trace_df.query("stream != -1 and index_correlation > 0")
 
         # CUDA stream wait event runtime calls and associated CUDA stream
         cudaStreamWaitEvent_id = sym_index.get("cudaStreamWaitEvent")

--- a/hta/common/trace_filter.py
+++ b/hta/common/trace_filter.py
@@ -288,11 +288,13 @@ class NameFilter(Filter):
         if symbol_table is None and self.symbol_table is None:
             return NameStringColumnFilter(self.name_pattern)(df)
         else:
-            _symbol_table = (
-                symbol_table
-                if symbol_table
-                else self.symbol_table if self.symbol_table else TraceSymbolTable()
-            )
+            if symbol_table:
+                _symbol_table = symbol_table
+            elif self.symbol_table:
+                _symbol_table = self.symbol_table
+            else:
+                _symbol_table = TraceSymbolTable()
+
             return NameIdColumnFilter(self.name_pattern)(df, _symbol_table)
 
 


### PR DESCRIPTION
## What does this PR do?
After profiling CPA code we found the functions `_get_cuda_event_record_df()` and `_get_cuda_stream_wait_event_df()` consume high amounts of time in the analysis. 

This turns out due to an expensive search to find the previous kernel launch and next kernel launch respectively. This tells use which kernel a cuda event record was on, or which kernel a cuda stream wait event will synchronize on an event.
```
       def _previous_launch(ts: int, pid: int, tid: int) -> Optional[int]:
            """Find the previous CUDA launch on same pid and tid"""
            df = runtime_calls.query(f"pid == {pid} and tid == {tid}")
            lower_neighbors = df[df["ts"] < ts]["ts"]
            return lower_neighbors.idxmax() if len(lower_neighbors) else None

        cuda_record_calls["index_previous_launch"] = cuda_record_calls.apply(
            lambda x: _previous_launch(x["ts"], x["pid"], x["tid"]), axis=1
        )
```
This search would be O(n^2) leading to pretty high execution time.

## Proposed change
In the change, we now have two new functions to construct the same dataframe but use a more efficient pandas  df approach.
1. Assign a `launch_id`. for all cuda kernel/memcpy launch events
2. Zip together the kernel launch and corresponding sync events and sort by time.
3. We then use `cummax()` or `cummin()` to find the previous or next `launch_id`.
4. Joining with the original dataframe we can convert `launch_id` to the index of the kernel launch event.

## Testing

Performance test show 10-100x improvements for these functions - see following screenshots.
![Screenshot 2024-03-20 at 2 39 11 PM](https://github.com/facebookresearch/HolisticTraceAnalysis/assets/6922212/e8407d72-2367-4c79-913a-db7cd640c892)
![Screenshot 2024-03-20 at 2 39 28 PM](https://github.com/facebookresearch/HolisticTraceAnalysis/assets/6922212/30edbb4b-761d-40e9-9518-76bb964570bf)

Overall running time reduced from `Wall time: 3min 8s` to `Wall time: 26.1 s`.

*Functional testing*- i checked for mismatches and there were none between old and new function.

### Unit Testing
Tesst pass 
`pytest tests/test_critical_path_analysis.py -k test_critical_path_analysis`

### Extensive tests
TODO need to run on at least several test cases.

## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [x] N/A
