### PR TITLE
add attribution for kernel-kernel delay and check for sync on same strea

### DIFF
--- a/tests/test_critical_path_analysis.py
+++ b/tests/test_critical_path_analysis.py
@@ -196,7 +196,7 @@ class CriticalPathAnalysisTestCase(unittest.TestCase):
         # Check that all edges have event attribution
         for u, v in cp_graph.edges:
             e = cp_graph.edges[u, v]["object"]
-            if e.type == CPEdgeType.OPERATOR_KERNEL:
+            if e.type in {CPEdgeType.OPERATOR_KERNEL, CPEdgeType.KERNEL_KERNEL_DELAY}:
                 self.assertTrue(
                     (u, v) in cp_graph.edge_to_event_map,
                     msg=f"edge = {(u,v)}, obj = {e}",


### PR DESCRIPTION
…ream

## What does this PR do?
This was helpful in while i was debugging a change in critical path graph while fixing #117 
It ensures that two GPU kernels do not get marked with sync dependencies on the same stream

## Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [x] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [x] N/A
