### PR TITLE
0507 add metadata parser ijson

### DIFF
--- a/hta/common/trace_parser.py
+++ b/hta/common/trace_parser.py
@@ -352,9 +352,16 @@ def _parse_trace_dataframe_ijson(
     Returns:
         pd.DataFrame: parsed trace dataframe.
     """
-    meta: Dict[str, Any] = {}
-    # XXX handle adding metadata
-    # k: v for k, v in trace_record.items() if k != "traceEvents"}
+    # Parse trace metadata swiftly
+    meta: MetaData = {}
+    with _open_trace_file(trace_file_path) as fh:
+        t_start = time.perf_counter_ns()
+        meta = parse_metadata_ijson(fh)
+        t_end = time.perf_counter_ns()
+        logger.warning(
+            f"Parsed {trace_file_path} metadata in "
+            f"{(t_end - t_start)/1000000:.2f} milli seconds"
+        )
 
     if batched:
         df = _parse_trace_events_ijson_batched(trace_file_path, cfg, compress_on_fly)

--- a/tests/test_trace_parse.py
+++ b/tests/test_trace_parse.py
@@ -162,7 +162,6 @@ class TraceParseTestCase(unittest.TestCase):
             )
 
     def test_trace_metadata(self) -> None:
-        return
         trace_meta = self.vision_transformer_t.meta_data[0]
         exp_meta = EXPECTED_META_VISION_TRANFORMER
         self.assertEqual(trace_meta["schemaVersion"], exp_meta["schemaVersion"])
@@ -170,10 +169,11 @@ class TraceParseTestCase(unittest.TestCase):
         self.assertEqual(
             trace_meta["deviceProperties"][0], exp_meta["deviceProperties"][0]
         )
+        # print(trace_meta)
 
 
 @unittest.skipIf(
-    #    _auto_detect_parser_backend() == ParserBackend.JSON,
+    # _auto_detect_parser_backend() == ParserBackend.JSON,
     # Tests are timing out the CI so have to disable this
     1,
     "Skipping ijson based trace load tests",
@@ -236,7 +236,8 @@ class TraceParseIjsonOthersTestCase(unittest.TestCase):
         trace_meta = {}
         with _open_trace_file(trace_file_path) as fh:
             trace_meta = parse_metadata_ijson(fh)
-        
+        # print(trace_meta)
+
         exp_meta = EXPECTED_META_VISION_TRANFORMER
         self.assertEqual(trace_meta["schemaVersion"], exp_meta["schemaVersion"])
         self.assertEqual(trace_meta["distributedInfo"], exp_meta["distributedInfo"])

--- a/tests/test_trace_parse.py
+++ b/tests/test_trace_parse.py
@@ -5,7 +5,7 @@
 import os
 import unittest
 
-from typing import Dict
+from typing import Any, Dict
 
 # import unittest.mock as mock
 
@@ -13,10 +13,35 @@ import pandas as pd
 from hta.common.trace import parse_trace_dict, Trace
 from hta.common.trace_parser import (
     _auto_detect_parser_backend,
+    _open_trace_file,
     get_default_trace_parsing_backend,
+    parse_metadata_ijson,
     ParserBackend,
     set_default_trace_parsing_backend,
 )
+
+EXPECTED_META_VISION_TRANFORMER: Dict[str, Any] = {
+    "schemaVersion": 1,
+    "distributedInfo": {"backend": "nccl", "rank": 0, "world_size": 64},
+    "deviceProperties": [
+        {
+            "id": 0,
+            "name": "Tesla V100-SXM2-32GB",
+            "totalGlobalMem": 34089730048,
+            "computeMajor": 7,
+            "computeMinor": 0,
+            "maxThreadsPerBlock": 1024,
+            "maxThreadsPerMultiprocessor": 2048,
+            "regsPerBlock": 65536,
+            "regsPerMultiprocessor": 65536,
+            "warpSize": 32,
+            "sharedMemPerBlock": 49152,
+            "sharedMemPerMultiprocessor": 98304,
+            "numSms": 80,
+            "sharedMemPerBlockOptin": 98304,
+        },
+    ],
+}
 
 GROUND_TRUTH_CACHE: Dict[str, pd.DataFrame] = {}
 
@@ -136,6 +161,16 @@ class TraceParseTestCase(unittest.TestCase):
                 gpu_kernels_per_iteration, correlated_cpu_ops_per_iteration
             )
 
+    def test_trace_metadata(self) -> None:
+        return
+        trace_meta = self.vision_transformer_t.meta_data[0]
+        exp_meta = EXPECTED_META_VISION_TRANFORMER
+        self.assertEqual(trace_meta["schemaVersion"], exp_meta["schemaVersion"])
+        self.assertEqual(trace_meta["distributedInfo"], exp_meta["distributedInfo"])
+        self.assertEqual(
+            trace_meta["deviceProperties"][0], exp_meta["deviceProperties"][0]
+        )
+
 
 @unittest.skipIf(
     #    _auto_detect_parser_backend() == ParserBackend.JSON,
@@ -162,10 +197,12 @@ class TraceParseIjsonOthersTestCase(unittest.TestCase):
     """Additional test for coverage of 2 other backends"""
 
     inference_trace_dir: str
+    vision_transformer_trace_dir: str
 
     @classmethod
     def setUpClass(cls):
-        cls.inference_trace_dir: str = "tests/data//critical_path/alexnet"
+        cls.inference_trace_dir: str = "tests/data/critical_path/alexnet"
+        cls.vision_transformer_trace_dir: str = "tests/data/vision_transformer"
 
     def test_ijson_parser(self):
         set_default_trace_parsing_backend(ParserBackend.IJSON)
@@ -193,6 +230,19 @@ class TraceParseIjsonOthersTestCase(unittest.TestCase):
 
         self.assertEqual(len(inference_t.traces), 1)
         set_default_trace_parsing_backend(ParserBackend.JSON)
+
+    def test_ijson_metadata_reader(self):
+        trace_file_path = self.vision_transformer_trace_dir + "/rank-0.json.gz"
+        trace_meta = {}
+        with _open_trace_file(trace_file_path) as fh:
+            trace_meta = parse_metadata_ijson(fh)
+        
+        exp_meta = EXPECTED_META_VISION_TRANFORMER
+        self.assertEqual(trace_meta["schemaVersion"], exp_meta["schemaVersion"])
+        self.assertEqual(trace_meta["distributedInfo"], exp_meta["distributedInfo"])
+        self.assertEqual(
+            trace_meta["deviceProperties"][0], exp_meta["deviceProperties"][0]
+        )
 
     # @mock.patch('ijson.backend')
     # def test_optimal_backend_detection(self, mock_backend) -> None:


### PR DESCRIPTION
## What does this PR do?
This PR adds a final missing feature in ijson parser. We need to obtain trace metadata in addition to the events.
This change uses ijson.parse() API to construct the trace metadata and immediately stops when it sees "traceEvents"
There is more inline documentation for it.

## Unit Testing
Added a new test 
  `pytest tests/test_trace_parse.py -k test_ijson_metadata_reader`

And metadata tests on main trace parser class
  `pytest tests/test_trace_parse.py -k test_trace_metadata`

## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [x] N/A
