### PR TITLE
[critical path] Add tolerance for negative one weight due to precision issues, improvements

### DIFF
--- a/tests/test_critical_path_analysis.py
+++ b/tests/test_critical_path_analysis.py
@@ -307,6 +307,19 @@ class CriticalPathAnalysisTestCase(unittest.TestCase):
                     trace_edge_counts["critical"], sum(trace_edge_counts.values())
                 )
 
+        # is it resilient to missing overlaid path?
+        tmpdir = "/tmp/path_does_not_exist"
+        overlaid_trace = critical_path_t.overlay_critical_path_analysis(
+            0,
+            cp_graph,
+            output_dir=tmpdir,
+            only_show_critical_events=False,
+            show_all_edges=True,
+        )
+        self.assertTrue(os.path.exists(tmpdir))
+        os.remove(overlaid_trace)
+        os.removedirs(tmpdir)
+
         # AlexNet has inter-stream synchronization using CUDA Events
         critical_path_t = self.alexnet_trace
 


### PR DESCRIPTION
## What does this PR do?
* Add tolerance for negative one weight due to precision issues
* No need to have overlaid director exist, now just mkdir it
## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [x] N/A
