### PR TITLE
Fix CPU kernel start time check when `include_last_profiler_step=True`

### DIFF
--- a/hta/common/trace.py
+++ b/hta/common/trace.py
@@ -629,10 +629,15 @@ class Trace:
             last_profiler_start = cpu_kernels[cpu_kernels["name"].isin(profiler_steps)][
                 "ts"
             ].max()
-            if include_last_profiler_step:
-                cpu_kernels = cpu_kernels[cpu_kernels["ts"] <= last_profiler_start]
-            else:
-                cpu_kernels = cpu_kernels[cpu_kernels["ts"] < last_profiler_start]
+            last_profiler_end = cpu_kernels[cpu_kernels["name"].isin(profiler_steps)][
+                "end"
+            ].max()
+
+            cpu_kernels = (
+                cpu_kernels[cpu_kernels["ts"] <= last_profiler_end]
+                if include_last_profiler_step
+                else cpu_kernels[cpu_kernels["ts"] < last_profiler_start]
+            )
             filtered_gpu_kernels = gpu_kernels.merge(
                 cpu_kernels["correlation"], on="correlation", how="inner"
             )


### PR DESCRIPTION
Summary:
The CPU kernerl start time check for including the last profiler step's events was incorrect.
Currently it is:
`cpu_kernels["ts"] <= last_profiler_start`
when it should be
`cpu_kernels["ts"]  <= last_profiler_end`

Reviewed By: briancoutinho

Differential Revision: D57382279


