### PR TITLE
fix submodule dependency for test_execution_trace in  .github/workflo…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           pip install -r requirements.txt
-          git submodule sync
-          git submodule update --init
 
       - name: Run tests
         run: |
           pip install pytest pytest-cov
+          git submodule sync
+          git submodule update --init
           pytest tests/*.py --doctest-modules --junitxml=junit/test-results.xml --cov-report=xml --cov-report=html


### PR DESCRIPTION
…ws/ci.yml

## What does this PR do?

The unit tests report an ImportError "ModuleNotFoundError: No module named 'et_replay'" while importing the test module "tests/test_execution_trace.py". This PR fixes this issue by running the command "git submodule sync; git submodule update --init" before running "pytest". 

## Before submitting

- [X] Was this discussed/approved via a GitHub issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [X] N/A
- [ ] Did you make sure to update the docs?
  - [X] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [X] N/A
