### PR TITLE
Correct Comm/comp Overlap Calculation

### DIFF
--- a/hta/utils/utils.py
+++ b/hta/utils/utils.py
@@ -3,6 +3,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import multiprocessing as mp
+import re
 from enum import Enum
 from pathlib import Path
 from typing import List, Tuple
@@ -15,6 +16,7 @@ class KernelType(Enum):
     COMMUNICATION = 0
     MEMORY = 1
     COMPUTATION = 2
+    OTHER = 3
 
 
 class IdleTimeType(Enum):
@@ -76,13 +78,27 @@ def is_memory_kernel(name: str) -> bool:
     return "Memcpy" in name or "Memset" in name
 
 
+def is_computer_kernel(name: str) -> bool:
+    """
+    Check if a given GPU kernel is a computation kernel.
+    Args:
+        name (str): name of the GPU kernel.
+    Returns:
+        A boolean indicating if the kernel is a computation kernel.
+    """
+    non_computer_kernel_re = re.compile(r"(^ncclKernel)|(.*(Memcpy)|(Memset))|(.*Sync)")
+    return not non_computer_kernel_re.match(name)
+
+
 def get_kernel_type(name: str) -> str:
     if is_comm_kernel(name):
         return KernelType.COMMUNICATION.name
     elif is_memory_kernel(name):
         return KernelType.MEMORY.name
-    else:
+    elif is_computer_kernel(name):
         return KernelType.COMPUTATION.name
+    else:
+        return KernelType.OTHER.name
 
 
 def get_memory_kernel_type(name: str) -> str:


### PR DESCRIPTION
Summary: Device Sync, Stream Sync and Event Sync were introduced to traces and they were mistakenly treated as computation kernels, which lead to falsely higher Comm/Comp overlap ratio. This diff removes these kernels from computation kernels.

Reviewed By: fengxizhou

Differential Revision: D59533863
