### PR TITLE
Add ns rounding to ijson loader too, make it configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - (Experimental) Added save and restore feature for critical path graph.
 - Add nccl collective fields to parser config
 - Fix ijson metadata parser for some corner cases
+- Add an option for ns rounding and cover ijson loading with it.
 
 #### Changed
 - Change test data path in unittests from relative path to real path to support running test within IDEs.


### PR DESCRIPTION
## What does this PR do?

Add ns rounding to ijson loader too.
Add an env flag "HTA_DISABLE_NS_ROUNDING" to disable this feature

## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [ ] N/A
