### PR TITLE
Normalize stream numbers

### DIFF
--- a/hta/common/trace_parser.py
+++ b/hta/common/trace_parser.py
@@ -26,6 +26,7 @@ from hta.configs.parser_config import (
     ParserConfig,
     ValueType,
 )
+from hta.utils.utils import normalize_gpu_stream_numbers
 
 # from memory_profiler import profile
 
@@ -386,6 +387,7 @@ def _parse_trace_dataframe_ijson(
         df = _parse_trace_events_ijson(trace_file_path)
 
     round_down_time_stamps(df)
+    normalize_gpu_stream_numbers(df)
 
     # assign an index to each event
     df.reset_index(inplace=True)


### PR DESCRIPTION
Summary:
We've observed cases where events' stream numbers are strings (i.e. "0") which causes HTA to crash.

There are two cases of string stream numbers we've observed.
1. CPU ops in PT2 traces
2. AMD GPU traces

This change addresses 1), but sets up the foundation to properly handle 2) - this will be addressed in a future PR.

Differential Revision: D60117101
