### PR TITLE
[critical path] Optimize graph construction of node events

### DIFF
--- a/hta/analyzers/critical_path_analysis.py
+++ b/hta/analyzers/critical_path_analysis.py
@@ -375,17 +375,10 @@ class CPGraph(nx.DiGraph):
     def _create_event_nodes(self) -> None:
         """Generates a start and end node for every event we would like
         to represent in our graph"""
-
-        # XXX TODO move these to symbol table
-        sym_index = self.symbol_table.get_sym_id_map()
-        cpu_op_id = sym_index.get("cpu_op")
-        cuda_runtime_id = sym_index.get("cuda_driver", -1000)
-        cuda_driver_id = sym_index.get("cuda_runtime", -1000)
-
         events_df = (
             self.trace_df.query(
-                f"cat == {cpu_op_id} or cat == {cuda_runtime_id} or cat == {cuda_driver_id}"
-                "or (stream != -1 and index_correlation >= 0)"
+                self.symbol_table.get_operator_or_cuda_runtime_query()
+                + " or (stream != -1 and index_correlation >= 0)"
             )[["index", "ts", "dur"]]
         ).rename(columns={"index": "ev_idx"})
 

--- a/hta/common/trace_symbol_table.py
+++ b/hta/common/trace_symbol_table.py
@@ -122,25 +122,25 @@ class TraceSymbolTable:
             "Expect both name and cat columns of string types to be present in the dataframe"
         )
 
-    def is_cuda_runtime(self, trace_df: pd.DataFrame, idx: int) -> bool:
-        """Check if an event is a CUDA runtime event"""
-        return trace_df["cat"].loc[idx] == self.sym_index["cuda_runtime"] or (
-            "cuda_driver" in self.sym_index.keys()
-            and (trace_df["cat"].loc[idx] == self.sym_index["cuda_driver"])
-        )
+    # Use a number lower than -1 as a sentinel for missing symbols
+    NULL: int = -128
 
-    def is_operator(self, trace_df: pd.DataFrame, idx: int) -> bool:
-        """Check if an event is a CPU operator"""
-        return trace_df["cat"].loc[idx] == self.sym_index["cpu_op"]
+    def get_operator_or_cuda_runtime_query(self) -> str:
+        """Returns a SQL query you can pass to trace dataframe query()
+        to filter events that are CUDA runtime events or operators."""
+        cpu_op_id = self.sym_index.get("cpu_op")
+        cuda_runtime_id = self.sym_index.get("cuda_driver", self.NULL)
+        cuda_driver_id = self.sym_index.get("cuda_runtime", self.NULL)
+        return f"(cat == {cpu_op_id} or cat == {cuda_runtime_id} or cat == {cuda_driver_id})"
 
     def get_runtime_launch_events_query(self) -> str:
         """Returns a SQL query you can pass to trace dataframe query()
         to filter events that are CUDA runtime kernel and memcpy launches."""
-        cudaLaunchKernel_id = self.sym_index.get("cudaLaunchKernel", -128)
-        cudaLaunchKernelExC_id = self.sym_index.get("cudaLaunchKernelExC", -128)
-        cuLaunchKernel_id = self.sym_index.get("cuLaunchKernel", -128)
-        cudaMemcpyAsync_id = self.sym_index.get("cudaMemcpyAsync", -128)
-        cudaMemsetAsync_id = self.sym_index.get("cudaMemsetAsync", -128)
+        cudaLaunchKernel_id = self.sym_index.get("cudaLaunchKernel", self.NULL)
+        cudaLaunchKernelExC_id = self.sym_index.get("cudaLaunchKernelExC", self.NULL)
+        cuLaunchKernel_id = self.sym_index.get("cuLaunchKernel", self.NULL)
+        cudaMemcpyAsync_id = self.sym_index.get("cudaMemcpyAsync", self.NULL)
+        cudaMemsetAsync_id = self.sym_index.get("cudaMemsetAsync", self.NULL)
 
         return (
             f"((name == {cudaMemsetAsync_id}) or (name == {cudaMemcpyAsync_id}) or "

--- a/tests/test_critical_path_analysis.py
+++ b/tests/test_critical_path_analysis.py
@@ -83,7 +83,7 @@ class CriticalPathAnalysisTestCase(unittest.TestCase):
         self.assertEqual(get_node_name(clamp_min_idx), "aten::clamp_min_")
         self.assertEqual(get_node_name(cuda_launch_idx), "cudaLaunchKernel")
 
-        expected_node_ids = [(32, 33), (34, 35), (36, 37)]
+        expected_node_ids = [(57, 62), (58, 61), (59, 60)]
 
         def check_nodes(ev_idx: int) -> Tuple[int, int]:
             start_node, end_node = cp_graph.get_nodes_for_event(ev_idx)


### PR DESCRIPTION
## What does this PR do?

In constructing critical graph we tend to access elements in the dataframe individually (`.loc[]`) which is really slow. This PR will try to fix these access.
* Completely remove `add_event()` function and instead construct the nodes for all events together using the dataframe itself. This will be a lot faster.
* Further, we seperate out the map from event to node ids into two maps.
* Remove the `is_operator_or_runtime` call as it does indexing into the dataframe, this handled directly in node construction time.

## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [ ] N/A
