### PR TITLE
Add option to filter events in call stack

### DIFF
--- a/hta/common/call_stack.py
+++ b/hta/common/call_stack.py
@@ -14,6 +14,7 @@ import numpy as np
 import pandas as pd
 
 from hta.common.trace import Trace
+from hta.common.trace_filter import Filter
 
 NON_EXISTENT_NODE_INDEX = -2
 NULL_NODE_INDEX = -1
@@ -198,7 +199,7 @@ class CallStackGraph:
         device_type (DeviceType) : what type of device that the call stack resides.
         correlations (pd.Series) : a Series that maps a node index to the index of a correlated node.
         depth (pd.Series) : a Series that maps a node index to the depth of the node.
-        filter_query (str) : used to preprocess the trace events and filter events out.
+        filter_func (Callable) : used to preprocess the trace events and filter events out. Please see filters in hta/common/trace_filter.py for details.
 
     Notes:
     + Because the kernels on a GPU has only one level, we don't construct a call stack for GPU kernels.
@@ -208,7 +209,7 @@ class CallStackGraph:
         self,
         df: pd.DataFrame,
         identity: CallStackIdentity,
-        filter_query: Optional[str] = None,
+        filter_func: Optional[Filter] = None,
     ) -> None:
         """Construct an empty graph."""
         self.df = df
@@ -217,7 +218,7 @@ class CallStackGraph:
         self.nodes: Dict[int, CallStackNode] = {}
         self.correlations: pd.Series = None
         self.depth: pd.Series = None
-        self.filter_query: Optional[str] = filter_query
+        self.filter_func: Optional[Filter] = filter_func
         self._construct_call_stack_graph(df)
         self._compute_depth()
 
@@ -249,8 +250,8 @@ class CallStackGraph:
         self.nodes.clear()
         self.nodes[NULL_NODE_INDEX] = CallStackNode(NULL_NODE_INDEX, -1, [])
         events = []
-        if self.filter_query is not None:
-            df = df.query(self.filter_query)[["index", "ts", "dur"]].copy()
+        if self.filter_func is not None:
+            df = self.filter_func(df)[["index", "ts", "dur"]].copy()
         else:
             df = df[["index", "ts", "dur"]].copy()
         df["dur"] = np.maximum(df["dur"], 0)
@@ -460,14 +461,14 @@ class CallGraph:
         self,
         trace: Trace,
         ranks: Optional[List[int]] = None,
-        filter_query: Optional[str] = None,
+        filter_func: Optional[Filter] = None,
     ) -> None:
         """Construct a CallGraph from a Trace object <trace_data>
 
         Args:
             trace (Trace): the trace data used to construct this CallGraph object.
             ranks (List[int]) : filter the traces using the given set of ranks. Using all ranks if None.
-            filter_query (str) : used to preprocess the trace events and filter events out.
+            filter_func (Callable) : used to preprocess the trace events and filter events out. Please see filters in hta/common/trace_filter.py for details.
         Raises:
             ValueError: the trace data is invalid.
         """
@@ -476,17 +477,17 @@ class CallGraph:
         self.call_stacks: List[CallStackGraph] = []
 
         _ranks = [k for k in trace.get_all_traces()] if ranks is None else ranks
-        self._construct_call_graph(_ranks, filter_query)
+        self._construct_call_graph(_ranks, filter_func)
 
     def _construct_call_graph(
-        self, ranks: List[int], filter_query: Optional[str]
+        self, ranks: List[int], filter_func: Optional[Filter]
     ) -> None:
         """
         Construct the call graph from the traces of a distributed training job.
 
         Args:
             ranks (List[int]) : a list ranks to select traces for construct the call stacks.
-            filter_query (str) : used to preprocess the trace events and filter events out.
+            filter_func (Callable) : used to preprocess the trace events and filter events out. Please see filters in hta/common/trace_filter.py for details.
         """
         call_stack_ids: List[CallStackIdentity] = []
         t0 = perf_counter()
@@ -498,7 +499,7 @@ class CallGraph:
                     # Filter out gpu annotations and sync events
                     df_thread = df_thread[df_thread["stream"].gt(0)]
                 csi = CallStackIdentity(rank, pid, tid)
-                csg = CallStackGraph(df_thread, csi, filter_query)
+                csg = CallStackGraph(df_thread, csi, filter_func)
                 self.call_stacks.append(csg)
                 call_stack_ids.append(csi)
         t1 = perf_counter()

--- a/hta/common/trace_filter.py
+++ b/hta/common/trace_filter.py
@@ -299,6 +299,24 @@ class NameFilter(Filter):
             return NameIdColumnFilter(self.name_pattern)(df, _symbol_table)
 
 
+class QueryFilter:
+    """
+    A trace event filter class to select events matching a SQL condition
+    """
+
+    def __init__(self, query_str: str) -> None:
+        self.filter_query = query_str
+
+    def __call__(
+        self, df: pd.DataFrame, symbol_table: Optional[TraceSymbolTable] = None
+    ) -> pd.DataFrame:
+        return df.query(self.filter_query)
+
+
+# This filter matches rows where the duration is non zero.
+ZeroDurationFilter = QueryFilter("dur > 0")
+
+
 def _filter_gpu_kernels_with_cuda_sync(
     df: pd.DataFrame, symbol_table: TraceSymbolTable
 ):

--- a/tests/test_call_stack.py
+++ b/tests/test_call_stack.py
@@ -7,6 +7,7 @@ import unittest
 import pandas as pd
 
 from hta.common.call_stack import CallStackGraph, CallStackIdentity, CallStackNode
+from hta.common.trace_filter import ZeroDurationFilter
 
 
 class CallStackTestCase(unittest.TestCase):
@@ -75,7 +76,7 @@ class CallStackTestCase(unittest.TestCase):
         self.assertDictEqual(nodes, self.nodes)
 
     def test_construct_call_graph_0_dur(self):
-        csg = CallStackGraph(self.df2, self.csi2, filter_query="dur > 0")
+        csg = CallStackGraph(self.df2, self.csi2, filter_func=ZeroDurationFilter)
         nodes = csg.get_nodes()
         self.assertDictEqual(nodes, self.nodes2)
 


### PR DESCRIPTION
## What does this PR do?
Call stack does not provide correct results if events are of 0 duration. We want to provide an option to filer these events out.
To keep things extensible adding an optional filter_query(str) argument to call stack class.

## Testing:

Added a new short test case to check this works.
`pytest tests/test_call_stack.py`
  
## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [x] N/A
