### PR TITLE
add data_provider test utility

### DIFF
--- a/hta/utils/test_utils.py
+++ b/hta/utils/test_utils.py
@@ -1,0 +1,57 @@
+import copy
+import functools
+from typing import Any, Callable, Iterable
+
+
+def data_provider(
+    data_function: Callable[[], Iterable[Any]],
+) -> Callable[[Callable[..., None]], Callable[..., None]]:
+    """
+    A simple data provider decorator.
+
+    Args:
+        data_function: a Callable object that returns an iterable set of test data.
+
+    Note: This utility is created to support porting unit test code between HTA OSS and an HTA branch at Meta internal.
+
+    Usage of the decorator is as follows:
+
+    class TestTransform(unittest.TestCase):
+        # pyre-ignore[56]
+        def dataset():
+            return (
+              {'input_1': 'hello', 'expected_result': 'HeLlO'},
+              {'input_1': 'world', 'expected_result': 'WoRlD'}
+            )
+
+        @data_provider(dataset)
+        def test_transform(self, input_1: str,  expected_result: str):
+            self.assertEqual(transform(input_1), expected_result)
+
+        # pyre-ignore[56]
+        @data_provider(
+           lambda: (
+              {'input_1': 'hello', 'expected_result': 'HeLlO'},
+              {'input_1': 'world', 'expected_result': 'WoRlD'},
+            )
+         )
+        def test_transform2(self, input_1: str,  expected_result: str):
+            self.assertEqual(transform(input_1), expected_result)
+    """
+    # The decorator is dependent on the function providing the data.
+    def decorator(test_func: Callable[..., None]) -> Callable[..., None]:
+        @functools.wraps(test_func)
+        def wrapper(self, *args, **kwargs) -> None:
+            for data in data_function():
+                if isinstance(data, dict):
+                    kwargs_copy = copy.copy(kwargs)
+                    kwargs_copy.update(data)
+                    test_func(self, *args, **kwargs_copy)
+                elif isinstance(data, tuple):
+                    test_func(self, *(args + tuple(data)), **kwargs)
+                else:
+                    test_func(self, data)
+
+        return wrapper
+
+    return decorator

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -1,0 +1,21 @@
+import unittest
+
+from hta.utils.test_utils import data_provider
+
+
+class MyTestCase(unittest.TestCase):
+    @data_provider(
+        lambda: (
+            {
+                "var1": "Hello, ",
+                "var2": "HTA",
+                "expected_result": 10,
+            },
+        )
+    )
+    def test_data_provider(self, var1: str, var2: str, expected_result: int):
+        self.assertEqual(len(var1) + len(var2), expected_result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?
Fixes # 172.

This PR implements a data_provider utility which matches the same interface provided by the Meta "data_provider" interface. The objective is to reduce the efforts from porting the internal code to HTA without the need of rewriting those unit tests that use the internal `data_provider` utility. We didn't use the third-party implementations because they are not compatible with the signature and behavior of the internal utility. 

The usage of the data_provider is as follows:

class TestTransform(unittest.TestCase):
    # pyre-ignore[56]
    def dataset():
        return (
          {'input_1': 'hello', 'expected_result': 'HeLlO'},
          {'input_1': 'world', 'expected_result': 'WoRlD'},
        )

    @data_provider(dataset)
    def test_transform(self, input_1: str,  expected_result: str):
        self.assertEqual(transform(input_1), expected_result)

    # pyre-ignore[56]
    @data_provider(
       lambda: (
          {'input_1': 'hello', 'expected_result': 'HeLlO'},
          {'input_1': 'world', 'expected_result': 'WoRlD'},
        )
     )
    def test_transform2(self, input_1: str,  expected_result: str):
        self.assertEqual(transform(input_1), expected_result)

## Before submitting

- [X] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [X] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [X] N/A
- [X] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [ ] N/A
