### PR TITLE
add env options and disable negative weights check

### DIFF
--- a/hta/common/call_stack.py
+++ b/hta/common/call_stack.py
@@ -4,15 +4,15 @@
 
 import functools
 import logging
-import os
 from collections import namedtuple
 from enum import Enum
 from time import perf_counter
 from typing import Callable, Dict, List, NamedTuple, Optional
 
+import hta.configs.env_options as hta_options
+
 import numpy as np
 import pandas as pd
-
 from hta.common.trace import Trace
 from hta.common.trace_filter import Filter
 
@@ -20,7 +20,6 @@ NON_EXISTENT_NODE_INDEX = -2
 NULL_NODE_INDEX = -1
 EVENT_START = 1
 EVENT_END = -1
-HTA_DISABLE_CG_DEPTH_ENV = "HTA_DISABLE_CG_DEPTH"
 
 
 class DeviceType(Enum):
@@ -532,7 +531,7 @@ class CallGraph:
                     }
                 )
             df = self.trace_data.get_trace(rank)
-            if os.environ.get(HTA_DISABLE_CG_DEPTH_ENV, None) is None:
+            if not hta_options.disable_call_graph_depth():
                 depth = pd.concat(
                     [self.call_stacks[idx].get_depth() for idx in call_stack_indices]
                 )

--- a/hta/common/trace_parser.py
+++ b/hta/common/trace_parser.py
@@ -14,6 +14,8 @@ import tracemalloc
 from collections.abc import Generator
 from typing import Any, Dict, Optional, Tuple
 
+import hta.configs.env_options as hta_options
+
 import numpy as np
 
 import pandas as pd
@@ -30,12 +32,6 @@ from hta.utils.utils import normalize_gpu_stream_numbers
 
 # from memory_profiler import profile
 
-# Disables the rounding out of nanosecond precision traces.
-# The rounding was added due to the events overlapping when
-# the precision of events was increased.
-# To use this set HTA_DISABLE_NS_ROUNDING=1 or
-#  os.environ["HTA_DISABLE_NS_ROUNDING"] = "1" before initializing HTA
-HTA_DISABLE_NS_ROUNDING_ENV = "HTA_DISABLE_NS_ROUNDING"
 
 MetaData = Dict[str, Any]
 _TRACE_PARSING_BACKEND: Optional[ParserBackend] = None
@@ -305,7 +301,7 @@ def _compress_df(
 def round_down_time_stamps(df: pd.DataFrame) -> None:
     if df["ts"].dtype != np.dtype("float64"):
         return
-    if os.environ.get(HTA_DISABLE_NS_ROUNDING_ENV, "-1") == "1":
+    if hta_options.disable_ns_rounding():
         logger.warning("Rounding down ns resolution traces disabled")
         return
 

--- a/hta/configs/env_options.py
+++ b/hta/configs/env_options.py
@@ -1,0 +1,73 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+
+from typing import Optional
+
+
+""" HTA provides a set of options to modify behavior of the analyzers using environmenent variables.
+Note that all env variables are treated as strings, so for flag like options the values will be "1" or "0".
+"""
+
+# Disables the rounding out of nanosecond precision traces.
+# The rounding was added due to the events overlapping when the precision of events was increased.
+HTA_DISABLE_NS_ROUNDING_ENV = "HTA_DISABLE_NS_ROUNDING"
+
+# Disable adding CG depth in hta/common/call_stack.py
+HTA_DISABLE_CG_DEPTH_ENV = "HTA_DISABLE_CG_DEPTH"
+
+# -- Critical path analysis --
+# Add zero weight launch edges for causality.
+CP_LAUNCH_EDGE_ENV = "CRITICAL_PATH_ADD_ZERO_WEIGHT_LAUNCH_EDGE"
+# Show zero weight launch edges in overlaid trace.
+CP_LAUNCH_EDGE_SHOW_ENV = "CRITICAL_PATH_SHOW_ZERO_WEIGHT_LAUNCH_EDGE"
+
+# Fail when edges have negative weight, rather than correcting them to 0
+CP_STRICT_NEG_WEIGHT_CHECK_ENV = "CRITICAL_PATH_STRICT_NEGATIVE_WEIGHT_CHECKS"
+
+
+def _get_env(name: str) -> Optional[str]:
+    """Checks for env or returns None"""
+    return os.environ.get(name)
+
+
+def _check_env_flag(name: str, default: str = "0") -> bool:
+    """Checks if env flag is "1" """
+    if (value := _get_env(name)) is None:
+        value = default
+    return value == "1"
+
+
+def disable_ns_rounding() -> bool:
+    return _check_env_flag(HTA_DISABLE_NS_ROUNDING_ENV, "0")
+
+
+def disable_call_graph_depth() -> bool:
+    return _check_env_flag(HTA_DISABLE_CG_DEPTH_ENV, "0")
+
+
+def critical_path_add_zero_weight_launch_edges() -> bool:
+    return _check_env_flag(CP_LAUNCH_EDGE_ENV, "0")
+
+
+def critical_path_show_zero_weight_launch_edges() -> bool:
+    return _check_env_flag(CP_LAUNCH_EDGE_SHOW_ENV, "0")
+
+
+def critical_path_strict_negative_weight_check() -> bool:
+    return _check_env_flag(CP_STRICT_NEG_WEIGHT_CHECK_ENV, "0")
+
+
+def get_options() -> str:
+    def get_env(name: str) -> str:
+        return _get_env(name) or "unset"
+
+    return f"""
+disable_ns_rounding={disable_ns_rounding()}, HTA_DISABLE_NS_ROUNDING_ENV={get_env(HTA_DISABLE_NS_ROUNDING_ENV)}
+disable_call_graph_depth={disable_call_graph_depth()}, HTA_DISABLE_CG_DEPTH_ENV={get_env(HTA_DISABLE_CG_DEPTH_ENV)}
+critical_path_add_zero_weight_launch_edges={critical_path_add_zero_weight_launch_edges()}, CP_LAUNCH_EDGE_ENV={get_env(CP_LAUNCH_EDGE_ENV)}
+critical_path_show_zero_weight_launch_edges={critical_path_show_zero_weight_launch_edges()}, CP_LAUNCH_EDGE_SHOW_ENV={get_env(CP_LAUNCH_EDGE_SHOW_ENV)}
+critical_path_strict_negative_weight_check={critical_path_strict_negative_weight_check()}, CP_STRICT_NEG_WEIGHT_CHECK_ENV={get_env(CP_STRICT_NEG_WEIGHT_CHECK_ENV)}
+"""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,7 @@ import unittest
 
 from hta.configs.config import HtaConfig
 from hta.configs.default_values import DEFAULT_CONFIG_FILENAME
+from hta.configs.env_options import get_options
 
 
 class HtaConfigTestCase(unittest.TestCase):
@@ -68,6 +69,9 @@ class HtaConfigTestCase(unittest.TestCase):
         config = HtaConfig(self.test_config_path, load_default_paths=False)
         self.assertEqual(config.get_config("c", 10), self.test_config["c"])
         self.assertEqual(config.get_config("d", 10), 10)
+
+    def test_get_env_options(self):
+        self.assertNotEqual(get_options(), "")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_critical_path_analysis.py
+++ b/tests/test_critical_path_analysis.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Tuple
 
+import hta.configs.env_options as hta_options
 from hta.analyzers.critical_path_analysis import (
     CPEdge,
     CPEdgeType,
@@ -254,7 +255,7 @@ class CriticalPathAnalysisTestCase(unittest.TestCase):
                 cpgraph_edges = (
                     cp_graph.edges[u, v]["object"] for (u, v) in cp_graph.edges
                 )
-                if not CriticalPathAnalysis._show_zero_weight_launch_edges():
+                if not hta_options.critical_path_show_zero_weight_launch_edges():
                     cpgraph_edges = filter(
                         lambda e: not CriticalPathAnalysis._is_zero_weight_launch_edge(
                             e


### PR DESCRIPTION
## What does this PR do?
1. Adds a file to encapsulate environment variable based options.
2. Critical path, make negative weight check more tolerant

Testing:
pytest tests/test_config.py

We can also see the options.
```
>>> from hta.configs.env_options import get_options
>>> print(get_options())

disable_ns_rounding=False, HTA_DISABLE_NS_ROUNDING_ENV=unset
disable_call_graph_depth=False, HTA_DISABLE_CG_DEPTH_ENV=unset
critical_path_add_zero_weight_launch_edges=False, CP_LAUNCH_EDGE_ENV=unset
critical_path_show_zero_weight_launch_edges=False, CP_LAUNCH_EDGE_SHOW_ENV=unset
critical_path_strict_negative_weight_check=False, CP_STRICT_NEG_WEIGHT_CHECK_ENV=unset

```

## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [x] N/A
