### PR TITLE
Time blocked on kernel queue full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - (Experimental) Critical path analysis fixes: fixing async memcpy and adding GPU to CPU event based synchronization.
 - (Experimental) Added save and restore feature for critical path graph.
 - Add nccl collective fields to parser config
+- Queue length analysis: Add feature to compute time blocked on a stream hitting max queue length.
 
 #### Changed
 - Change test data path in unittests from relative path to real path to support running test within IDEs.

--- a/examples/trace_analysis_demo.ipynb
+++ b/examples/trace_analysis_demo.ipynb
@@ -24,14 +24,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 87,
    "id": "c8e32f5d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2024-08-22 11:27:02,545 - hta - trace.py:L329 - INFO - /Users/bcoutinho/Work/hta/queue_full_data\n",
+      "2024-08-22 11:27:02,561 - hta - trace_file.py:L102 - INFO - Rank to trace file map:\n",
+      "{1: '/Users/bcoutinho/Work/hta/queue_full_data/rank-1.Apr_10_22_19_54.3461.pt.trace.json.gz'}\n",
+      "2024-08-22 11:27:02,561 - hta - trace.py:L501 - INFO - ranks=[1]\n",
+      "2024-08-22 11:27:04,596 - hta - trace_parser.py:L111 - WARNING - Parsed /Users/bcoutinho/Work/hta/queue_full_data/rank-1.Apr_10_22_19_54.3461.pt.trace.json.gz time = 2.03 seconds \n",
+      "2024-08-22 11:27:06,097 - hta - trace_parser.py:L446 - WARNING - Parsed /Users/bcoutinho/Work/hta/queue_full_data/rank-1.Apr_10_22_19_54.3461.pt.trace.json.gz backend=json in 3.53 seconds; current PID:26558\n",
+      "2024-08-22 11:27:06,841 - hta - trace.py:L236 - WARNING - Overall parsing of /Users/bcoutinho/Work/hta/queue_full_data/rank-1.Apr_10_22_19_54.3461.pt.trace.json.gz in 4.28 seconds; current PID:26558\n",
+      "2024-08-22 11:27:06,934 - hta - trace.py:L475 - WARNING - leaving parse_multiple_ranks duration=4.37 seconds\n",
+      "2024-08-22 11:27:06,935 - hta - trace.py:L513 - WARNING - leaving parse_traces duration=4.37 seconds\n"
+     ]
+    }
+   ],
    "source": [
     "from hta.trace_analysis import TraceAnalysis\n",
     "\n",
-    "trace_dir = \"~/HolisticTraceAnalysis/tests/data/vision_transformer/\"\n",
+    "trace_dir = \"~/HolisticTraceAnalysis2/tests/data/vision_transformer/\"\n",
     "analyzer = TraceAnalysis(trace_dir=trace_dir)"
    ]
   },
@@ -1345,7 +1361,7 @@
    "id": "4919f5e4",
    "metadata": {},
    "source": [
-    "# Augmented Counters\n",
+    "# Augmented Counters (Queue length and Memory Bandwidth)\n",
     "\n",
     "### Description\n",
     "This feature adds counter/time series to the trace to visually debug time series.\n",
@@ -1361,10 +1377,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 95,
    "id": "4b513fc8",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mSignature:\u001b[0m\n",
+       "\u001b[0manalyzer\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgenerate_trace_with_counters\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mtime_series\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mhta\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtrace_analysis\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mTimeSeriesTypes\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mranks\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mList\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mint\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0moutput_suffix\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mstr\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m'_with_counters'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m->\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mDocstring:\u001b[0m\n",
+       "Adds a set of time series to the trace in order to aid debugging traces. Creates a new trace file\n",
+       "for each requested rank with the a suffix '_with_counters.json'. The following time series are\n",
+       "available in TimeSeriesTypes flag type.\n",
+       "\n",
+       "1. Queue length - adds a time series to the trace indicating the size of the queue at any given time on each CUDA stream.\n",
+       "2. Memory copy bandwidth - adds a time series to the trace indicating the memory bandwidth used for device to host, host to device and device to device operations.\n",
+       "\n",
+       "Either or both of the above can be enabled.\n",
+       "\n",
+       "Args:\n",
+       "    time_series (Flag): Used to set the requested time series. Available values are\n",
+       "        TimeSeriesTypes.QUEUE_LENGTH and TimeSeriesTypes.MEMCPY_BANDWIDTH. By default\n",
+       "        both time series are added to the trace.\n",
+       "    ranks (List[int]): List of ranks to generate the counters for. Default = [0].\n",
+       "    output_suffix (str): Suffix to add to the trace file. Default = '_with_counters.json.gz'\n",
+       "\n",
+       "Returns:\n",
+       "    None\n",
+       "\u001b[0;31mFile:\u001b[0m      ~/Work/hta/HolisticTraceAnalysis2/hta/trace_analysis.py\n",
+       "\u001b[0;31mType:\u001b[0m      method"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "analyzer.generate_trace_with_counters?"
    ]
@@ -1391,12 +1443,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 99,
    "id": "c8a2f9b8",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2024-08-22 11:29:45,339 - hta - trace_counters.py:L127 - INFO - Please note that the time series only contains points when the value changes. Once a values is observed the time series stays constant until the next update.\n",
+      "2024-08-22 11:29:47,197 - hta - trace_parser.py:L111 - WARNING - Parsed /Users/bcoutinho/Work/hta/queue_full_data/rank-1.Apr_10_22_19_54.3461.pt.trace.json.gz time = 1.63 seconds \n",
+      "2024-08-22 11:29:47,201 - hta - trace_analysis.py:L335 - INFO - Writing trace with counters for rank 1 to /Users/bcoutinho/Work/hta/queue_full_data/rank-1.Apr_10_22_19_54.3461.pt.trace_with_counters.json.gz\n"
+     ]
+    }
+   ],
    "source": [
-    "analyzer.generate_trace_with_counters()"
+    "from hta.trace_analysis import TimeSeriesTypes\n",
+    "\n",
+    "analyzer.generate_trace_with_counters(ranks=[1], time_series = TimeSeriesTypes.QUEUE_LENGTH)"
    ]
   },
   {
@@ -1426,7 +1490,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 88,
    "id": "96a6931c",
    "metadata": {},
    "outputs": [
@@ -1434,7 +1498,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2022-12-11 23:22:14,759 - hta - trace_counters.py:L94 - INFO - Please note that the time series only contains points when the value changes. Once a values is observed the time series stays constant until the next update.\n"
+      "2024-08-22 11:27:32,604 - hta - trace_counters.py:L127 - INFO - Please note that the time series only contains points when the value changes. Once a values is observed the time series stays constant until the next update.\n"
      ]
     },
     {
@@ -1492,130 +1556,52 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th rowspan=\"6\" valign=\"top\">0</th>\n",
+       "      <th rowspan=\"5\" valign=\"top\">1</th>\n",
        "      <th>7</th>\n",
-       "      <td>17160.0</td>\n",
-       "      <td>61.043473</td>\n",
-       "      <td>92.334500</td>\n",
+       "      <td>41296.0</td>\n",
+       "      <td>366.792232</td>\n",
+       "      <td>361.263264</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>9.0</td>\n",
-       "      <td>87.0</td>\n",
-       "      <td>403.0</td>\n",
+       "      <td>28.0</td>\n",
+       "      <td>252.0</td>\n",
+       "      <td>692.0</td>\n",
+       "      <td>1024.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>20</th>\n",
-       "      <td>72.0</td>\n",
-       "      <td>0.555556</td>\n",
-       "      <td>0.553831</td>\n",
+       "      <th>21</th>\n",
+       "      <td>1200.0</td>\n",
+       "      <td>0.808333</td>\n",
+       "      <td>1.064993</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
+       "      <td>7.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>23</th>\n",
+       "      <td>104.0</td>\n",
+       "      <td>3.730769</td>\n",
+       "      <td>2.213071</td>\n",
+       "      <td>0.0</td>\n",
        "      <td>2.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>24</th>\n",
-       "      <td>3016.0</td>\n",
-       "      <td>19.683024</td>\n",
-       "      <td>28.450842</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>2.0</td>\n",
-       "      <td>32.0</td>\n",
-       "      <td>108.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>26</th>\n",
-       "      <td>744.0</td>\n",
-       "      <td>9.768817</td>\n",
-       "      <td>6.932887</td>\n",
-       "      <td>0.0</td>\n",
        "      <td>4.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>14.0</td>\n",
-       "      <td>31.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>28</th>\n",
-       "      <td>32.0</td>\n",
-       "      <td>0.687500</td>\n",
-       "      <td>0.644455</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>2.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>30</th>\n",
+       "      <td>6.0</td>\n",
        "      <td>8.0</td>\n",
-       "      <td>0.500000</td>\n",
-       "      <td>0.534522</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.5</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>1.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th rowspan=\"6\" valign=\"top\">1</th>\n",
-       "      <th>7</th>\n",
-       "      <td>17164.0</td>\n",
-       "      <td>92.304008</td>\n",
-       "      <td>115.411311</td>\n",
+       "      <th>25</th>\n",
+       "      <td>728.0</td>\n",
+       "      <td>42.675824</td>\n",
+       "      <td>26.017228</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>49.0</td>\n",
-       "      <td>134.0</td>\n",
-       "      <td>407.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>20</th>\n",
-       "      <td>72.0</td>\n",
-       "      <td>0.555556</td>\n",
-       "      <td>0.553831</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>2.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>24</th>\n",
-       "      <td>3016.0</td>\n",
-       "      <td>27.533820</td>\n",
-       "      <td>30.211090</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>18.0</td>\n",
-       "      <td>43.0</td>\n",
-       "      <td>111.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>26</th>\n",
-       "      <td>744.0</td>\n",
-       "      <td>15.548387</td>\n",
-       "      <td>7.534243</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>17.0</td>\n",
        "      <td>20.0</td>\n",
-       "      <td>34.0</td>\n",
+       "      <td>42.5</td>\n",
+       "      <td>65.0</td>\n",
+       "      <td>88.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>28</th>\n",
-       "      <td>32.0</td>\n",
-       "      <td>0.750000</td>\n",
-       "      <td>0.672022</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>2.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>30</th>\n",
        "      <td>8.0</td>\n",
        "      <td>0.500000</td>\n",
        "      <td>0.534522</td>\n",
@@ -1630,30 +1616,32 @@
        "</div>"
       ],
       "text/plain": [
-       "            queue_length                                                      \n",
-       "                   count       mean         std  min   25%   50%    75%    max\n",
-       "rank stream                                                                   \n",
-       "0    7           17160.0  61.043473   92.334500  0.0   1.0   9.0   87.0  403.0\n",
-       "     20             72.0   0.555556    0.553831  0.0   0.0   1.0    1.0    2.0\n",
-       "     24           3016.0  19.683024   28.450842  0.0   1.0   2.0   32.0  108.0\n",
-       "     26            744.0   9.768817    6.932887  0.0   4.0  10.0   14.0   31.0\n",
-       "     28             32.0   0.687500    0.644455  0.0   0.0   1.0    1.0    2.0\n",
-       "     30              8.0   0.500000    0.534522  0.0   0.0   0.5    1.0    1.0\n",
-       "1    7           17164.0  92.304008  115.411311  0.0   1.0  49.0  134.0  407.0\n",
-       "     20             72.0   0.555556    0.553831  0.0   0.0   1.0    1.0    2.0\n",
-       "     24           3016.0  27.533820   30.211090  0.0   1.0  18.0   43.0  111.0\n",
-       "     26            744.0  15.548387    7.534243  0.0  10.0  17.0   20.0   34.0\n",
-       "     28             32.0   0.750000    0.672022  0.0   0.0   1.0    1.0    2.0\n",
-       "     30              8.0   0.500000    0.534522  0.0   0.0   0.5    1.0    1.0"
+       "            queue_length                                                   \\\n",
+       "                   count        mean         std  min   25%    50%    75%   \n",
+       "rank stream                                                                 \n",
+       "1    7           41296.0  366.792232  361.263264  0.0  28.0  252.0  692.0   \n",
+       "     21           1200.0    0.808333    1.064993  0.0   0.0    1.0    1.0   \n",
+       "     23            104.0    3.730769    2.213071  0.0   2.0    4.0    6.0   \n",
+       "     25            728.0   42.675824   26.017228  0.0  20.0   42.5   65.0   \n",
+       "     28              8.0    0.500000    0.534522  0.0   0.0    0.5    1.0   \n",
+       "\n",
+       "                     \n",
+       "                max  \n",
+       "rank stream          \n",
+       "1    7       1024.0  \n",
+       "     21         7.0  \n",
+       "     23         8.0  \n",
+       "     25        88.0  \n",
+       "     28         1.0  "
       ]
      },
-     "execution_count": 19,
+     "execution_count": 88,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "analyzer.get_queue_length_summary(ranks = [0, 1])"
+    "analyzer.get_queue_length_summary(ranks = [1])"
    ]
   },
   {
@@ -1668,17 +1656,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 111,
    "id": "04725d34",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mSignature:\u001b[0m \u001b[0manalyzer\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_queue_length_time_series\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mranks\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mList\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mint\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m->\u001b[0m \u001b[0mDict\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mint\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpandas\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcore\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mframe\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mDataFrame\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mDocstring:\u001b[0m\n",
+       "Queue length is defined as the number of outstanding CUDA operations on a stream. This\n",
+       "function calculates the time series for the queue length on each CUDA stream for the\n",
+       "specified ranks.\n",
+       "\n",
+       "Args:\n",
+       "    ranks (List[int]): List of ranks for which the queue length time series is generated. Default = [0].\n",
+       "\n",
+       "Returns:\n",
+       "    Dict[int, pd.DataFrame]\n",
+       "        Returns a dictionary whose key is the rank and value is a dataframe of queue length\n",
+       "        counter events. The following fields are in each row of the dataframe: ts (timestamp), pid (process id),\n",
+       "        tid (thread id), stream, and queue length.\n",
+       "\u001b[0;31mFile:\u001b[0m      ~/Work/hta/HolisticTraceAnalysis2/hta/trace_analysis.py\n",
+       "\u001b[0;31mType:\u001b[0m      method"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "analyzer.get_queue_length_time_series?"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 112,
    "id": "4539e91f",
    "metadata": {},
    "outputs": [
@@ -1686,12 +1699,148 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2022-12-11 23:22:14,909 - hta - trace_counters.py:L94 - INFO - Please note that the time series only contains points when the value changes. Once a values is observed the time series stays constant until the next update.\n"
+      "2024-08-22 12:46:35,722 - hta - trace_counters.py:L127 - INFO - Please note that the time series only contains points when the value changes. Once a values is observed the time series stays constant until the next update.\n"
      ]
     }
    ],
    "source": [
-    "queue_length_ts = analyzer.get_queue_length_time_series()"
+    "queue_length_dict = analyzer.get_queue_length_time_series(ranks=[1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0eeef515-9ab9-4b59-8ac2-fbdf00610464",
+   "metadata": {},
+   "source": [
+    "### Example 3\n",
+    "\n",
+    "#### Understanding time spent blocked on a kernel launch queue.\n",
+    "\n",
+    "The GPU kernels launch queue is finite. If the CPU fills up this queue, the CPU will block till the GPU device launches kernels. We compute the time spent blocked on a full or max launch queue using `get_time_spent_blocked_on_full_queue()`\n",
+    "\n",
+    "This function uses the queue length time series returned from `get_queue_length_time_series()` method above. The output is a dataframe with  two metrics : `duration_at_max_queue_length` and `relative_duration_at_max_queue_length` per `rank` and `stream`. Relative duration at max queue length considers the total duration of a trace and normalizes the `duration_at_max_queue_length`.\n",
+    "\n",
+    "We can leverage this function to see if a job is blocked on launching too many GPU kernels. Max queue length used is a tunable parameter for this analysis.\n",
+    "\n",
+    "### API 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 115,
+   "id": "73b74a79-0ec8-4957-ac7e-64eb8e98f7d6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mSignature:\u001b[0m\n",
+       "\u001b[0manalyzer\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_time_spent_blocked_on_full_queue\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mqueue_length_dict\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mDict\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mint\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpandas\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcore\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mframe\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mDataFrame\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mmax_queue_length\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mint\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m1024\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m->\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mpandas\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcore\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mframe\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mDataFrame\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mDocstring:\u001b[0m\n",
+       "The GPU kernels launch queue is finite. If the CPU fills up this queue the CPU\n",
+       "will block till the GPU device launches kernels. We compute the time spent blocked\n",
+       "on a full launch queue in this function.\n",
+       "\n",
+       "Returns an (optional) dataframe with the time spent on the kernel launch queue full.\n",
+       "This function takes the output from get_queue_length_time_series() and sums\n",
+       "up the time spent on all streams where the queue is full (see max_queue_length)\n",
+       "\n",
+       "Args:\n",
+       "    queue_length_dict (Dict[int, pd.DataFrame]): A dictionary of rank -> time series with the queue length of each CUDA stream.\n",
+       "        This is the output of get_queue_length_time_series().\n",
+       "    max_queue_length (int): Max kernel launch queue length.\n",
+       "\n",
+       "Returns:\n",
+       "    Optional[pd.DataFrame]\n",
+       "        An (optional) dataframe containing the summary statistics blocked time per\n",
+       "        stream and rank\n",
+       "        The dataframe contains the columns- rank, stream, duration_at_max_queue_length,\n",
+       "        and relative_duration_at_max_queue_length.\n",
+       "\n",
+       "        Relative duration at max queue length considers the total duration of a trace\n",
+       "        and normalizes the duration_at_max_queue_length.\n",
+       "\u001b[0;31mFile:\u001b[0m      ~/Work/hta/HolisticTraceAnalysis2/hta/trace_analysis.py\n",
+       "\u001b[0;31mType:\u001b[0m      method"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "analyzer.get_time_spent_blocked_on_full_queue?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 116,
+   "id": "b83e3f9f-58af-48d3-bd64-e254f5202eb0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2024-08-22 12:52:45,028 - hta - trace_counters.py:L237 - INFO - Rank=1, stream=7, total dur at max_queue = 183385.0\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>rank</th>\n",
+       "      <th>stream</th>\n",
+       "      <th>duration_at_max_queue_length</th>\n",
+       "      <th>relative_duration_at_max_queue_length</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>7</td>\n",
+       "      <td>183385.0</td>\n",
+       "      <td>0.088301</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   rank  stream  duration_at_max_queue_length  \\\n",
+       "0     1       7                      183385.0   \n",
+       "\n",
+       "   relative_duration_at_max_queue_length  \n",
+       "0                               0.088301  "
+      ]
+     },
+     "execution_count": 116,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "analyzer.get_time_spent_blocked_on_full_queue(queue_length_dict, max_queue_length=1024)"
    ]
   },
   {
@@ -2042,7 +2191,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.9.17"
   }
  },
  "nbformat": 4,

--- a/hta/common/constants.py
+++ b/hta/common/constants.py
@@ -1,0 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# The Max queue size is not really documented and is an implementation detail
+# https://forums.developer.nvidia.com/t/maximum-number-of-operations-in-a-stream/255260
+# We anecdotally see 1022 - 1024 to cause blocking of runtime operations.
+CUDA_MAX_LAUNCH_QUEUE_PER_STREAM: int = 1024

--- a/hta/common/trace.py
+++ b/hta/common/trace.py
@@ -527,6 +527,12 @@ class Trace:
         """Get the list of (sorted) ranks included in this trace."""
         return sorted(self.traces.keys())
 
+    def _get_first_rank(self, rank: Optional[int] = None) -> int:
+        if rank is None:
+            _ranks = self.get_ranks()
+            rank = _ranks[0] if len(_ranks) > 0 else -1
+        return rank
+
     def get_iterations(self, rank: Optional[int] = None) -> List[int]:
         """Get the list of iterations for a given rank.
 
@@ -538,15 +544,26 @@ class Trace:
             A list of iteration IDs for the given rank.
             Return an empty list when the rank is invalid or column "iteration" does not exists.
         """
-        if rank is None:
-            _ranks = self.get_ranks()
-            rank = _ranks[0] if len(_ranks) > 0 else -1
+        rank = self._get_first_rank(rank)
 
         if rank in self.get_ranks():
             df = self.traces[rank]
             if "iteration" in df.columns:
                 return sorted([i for i in df["iteration"].unique() if i >= 0])
         return []
+
+    def get_trace_duration(self, rank: Optional[int] = None) -> int:
+        """Get the duration of specified rank.
+
+        Args:
+            rank (Optional[int]): a rank
+                when rank is None, use the first item of the list returned by self.get_ranks().
+
+        Returns: duration of trace (int)
+        """
+        rank = self._get_first_rank(rank)
+        trace_df = self.get_trace(rank)
+        return trace_df.ts.max() - trace_df.ts.min()
 
     def get_trace(self, rank: int) -> pd.DataFrame:
         """


### PR DESCRIPTION
## What does this PR do?
WIP

Enables understanding the time blocked when the CUDA kernel queue is full. 
* Refactor queue length summary to take the time series data directly, makes it easy to reuse that result.
* Adds logic to check for time blocked on full queue
* Adds unit test
* Updated documentation
* Updated example notebook 

## Testing
`pytest tests/test_trace_analysis.py -k test_get_queue_length_stats`

## Docs
<img width="1121" alt="Screenshot 2024-08-22 at 12 52 22 PM" src="https://github.com/user-attachments/assets/8abb9730-0ca7-4b39-b7df-b675201af383">


## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [x] Did you make sure to update the docs?
  - [ ] N/A
- [x] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [ ] N/A
