### PR TITLE
add option to pass trace_file list to Trace() object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,16 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - (Experimental) Added lightweight critical path analysis feature.
 - (Experimental) Critical path analysis features: event attribution and `summary()`
 - (Experimental) Critical path analysis fixes: fixing async memcpy and adding GPU to CPU event based synchronization.
-- Add a workaround for overlapping events when using ns resolution traces (https://github.com/pytorch/pytorch/pull/122425)
-- Better handling of CUDA sync events with steam = -1
 - (Experimental) Added save and restore feature for critical path graph.
 - Add nccl collective fields to parser config
-- Fix ijson metadata parser for some corner cases
-- Add an option for ns rounding and cover ijson loading with it.
 
 #### Changed
 - Change test data path in unittests from relative path to real path to support running test within IDEs.
+- Add a workaround for overlapping events when using ns resolution traces (https://github.com/pytorch/pytorch/pull/122425)
+- Better handling of CUDA sync events with steam = -1
+- Fix ijson metadata parser for some corner cases
+- Add an option for ns rounding and cover ijson loading with it.
+- Updated Trace() api to specify a list of files and auto figure out ranks.
 
 #### Deprecated
 - Deprecated 'call_stack'; use 'trace_call_stack' and 'trace_call_graph' instead.

--- a/tests/test_trace_file.py
+++ b/tests/test_trace_file.py
@@ -83,10 +83,9 @@ class TestTraceFile(unittest.TestCase):
 
     def test_create_rank_to_trace_dict_with_mixed_dir(self) -> None:
         with self.assertLogs(logger, level="WARNING") as cm:
-            self.assertEqual(
-                create_rank_to_trace_dict_from_dir(self.trace_mixed_files),
-                (True, {0: "tests/data/mixed_files/rank_non_gpu.json.gz"}),
-            )
+            ok, res_dict = create_rank_to_trace_dict_from_dir(self.trace_mixed_files)
+            self.assertTrue(ok)
+            self.assertEqual(list(res_dict.keys()), [0])
             self.assertIn("has the same rank", cm.output[0])
 
     def test_create_rank_to_trace_dict_with_file_list(self) -> None:

--- a/tests/test_trace_parse.py
+++ b/tests/test_trace_parse.py
@@ -98,6 +98,9 @@ class TraceParseTestCase(unittest.TestCase):
         inference_trace_dir: str = "tests/data/inference_single_rank"
         vision_transformer_rank_0_file: str = "rank-0.json.gz"
         inference_rank_0_file: str = "inference_rank_0.json.gz"
+        inference_trace_files = [
+            os.path.join(inference_trace_dir, inference_rank_0_file)
+        ]
         max_ranks = 8
 
         # Trace parser for vision transformer
@@ -109,7 +112,9 @@ class TraceParseTestCase(unittest.TestCase):
             vision_transformer_trace_dir, vision_transformer_rank_0_file
         )
         # Trace parser for inference
-        cls.inference_t: Trace = Trace(trace_dir=inference_trace_dir)
+        cls.inference_t: Trace = Trace(
+            trace_files=inference_trace_files, trace_dir=os.getcwd()
+        )
         cls.inference_t.parse_traces(max_ranks=max_ranks, use_multiprocessing=True)
         cls.inference_raw_df = prepare_ground_truth_df(
             inference_trace_dir, inference_rank_0_file


### PR DESCRIPTION
## What does this PR do?
1. Allows users to enter a list of trace_files in Trace class. HTA will then determine rank to trace file mapping.
1. Makes it so that you do not need "distributedInfo", HTa will now default to rank = 0 and emit a warning.

Code example for (1)
```
        inference_trace_files = ["tests/data/inference_single_rank/inference_rank_0.json.gz"]
        trace: Trace = Trace(
            trace_files=inference_trace_files, trace_dir=os.getcwd()
        )
```

## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [x] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [] N/A
