### PR TITLE
replace uses of suffixes as list-of-two to tuple in DataFrame.merge invocations

### DIFF
--- a/hta/analyzers/critical_path_analysis.py
+++ b/hta/analyzers/critical_path_analysis.py
@@ -571,7 +571,7 @@ class CPGraph(nx.DiGraph):
                 gpu_kernels[["stream", "index", "pid"]],
                 left_on="index_correlation",
                 right_on="index",
-                suffixes=["", "_kernel"],
+                suffixes=("", "_kernel"),
             )
             .set_index("index")
         ).rename(columns={"pid_kernel": "gpu_kernel"})
@@ -688,7 +688,7 @@ class CPGraph(nx.DiGraph):
                 left_on="previous_launch_id",
                 right_on="launch_id",
                 how="left",
-                suffixes=["", "_launch_event"],
+                suffixes=("", "_launch_event"),
                 # multiple CUDA records can have same previous launch ID, but not vice versa
                 validate="many_to_one",
             )
@@ -771,7 +771,7 @@ class CPGraph(nx.DiGraph):
                 gpu_kernels[["stream", "index"]],
                 left_on="index_correlation",
                 right_on="index",
-                suffixes=["", "_kernel"],
+                suffixes=("", "_kernel"),
             )
             .set_index("index")
         )
@@ -805,7 +805,7 @@ class CPGraph(nx.DiGraph):
                 left_on="next_launch_id",
                 right_on="launch_id",
                 how="left",
-                suffixes=["", "_launch_event"],
+                suffixes=("", "_launch_event"),
             )
 
         pid_tid_streams = (
@@ -929,7 +929,7 @@ class CPGraph(nx.DiGraph):
                     left_on="wait_on_cuda_event_record_corr_id",
                     right_on="correlation",
                     how="left",
-                    suffixes=["", "_cuda_record"],
+                    suffixes=("", "_cuda_record"),
                 )
                 .fillna(-1)
                 .astype(int)


### PR DESCRIPTION
Summary:
Numpy-1.24.x provide extra type annotations. `DataFrame.merge` now defines `suffixes` argument as a tuple. While list of two still works, Pyre generates the following error:
```counterexample
Incompatible parameter type [6]: In call `pd.core.reshape.merge.merge`, for argument `suffixes`, expected `Tuple[Optional[str], Optional[str]]` but got `List[str]`.
```

Facilitate the upgrade, by proactively changing uses of list-of-two to a tuple with the following one-liner:
```
fbgs -ls 'suffixes=[' | xargs perl -0777 -MRegexp::Common=balanced -pi -e \
  's/(merge$RE{balanced}{-parens=>"()"})/(my $x = $1) =~ s|suffixes=\[([^\]]+)\]|suffixes=(\1)|s; $x/sge'
```
This finds all uses of `merge.(...suffixes=[...]...)` and replaces it with `merge(...suffixes=(...)...)`. Then inspected all uses and manually fixed one case where the replacement was not performed correctly due to complex `suffixes` values (extra `[]` and `()`).

Removed a few now unnecessary pyre-ignore comments:
```lang=python
# pyre-fixme[6]: For 4th argument expected `Tuple[Optional[str], Optional[str]]` but got `List[str]`.
```

Differential Revision: D62041393
