### PR TITLE
replace uses of agg("operation") with aggregate_func()

### DIFF
--- a/tests/test_trace_parse.py
+++ b/tests/test_trace_parse.py
@@ -175,10 +175,10 @@ class TraceParseTestCase(unittest.TestCase):
                 df.loc[valid_gpu_kernels.index, "index_correlation"]
             ]
             gpu_kernels_per_iteration = (
-                valid_gpu_kernels.groupby("iteration")["index"].agg("count").to_dict()
+                valid_gpu_kernels.groupby("iteration")["index"].count().to_dict()
             )
             correlated_cpu_ops_per_iteration = (
-                correlated_cpu_ops.groupby("iteration")["index"].agg("count").to_dict()
+                correlated_cpu_ops.groupby("iteration")["index"].count().to_dict()
             )
 
             self.assertTrue("iteration" in df.columns)


### PR DESCRIPTION
Summary:
X-link: https://github.com/ctrl-labs/src2/pull/34567

Pandas-2.0.0 changed default behavior of many methods on `DataFrame` that take argument `numeric_only` (for example `sum`, `mean`, etc). In the past, if `numeric_only`, the default value was `None`, and resulted into non-numeric columns being silently dropped. Now, the default value of `numeric_only` is `True`. This has two consequences:
* a non-numeric columns that supports the aggregation function is now included in the result. For example, if the type of a column is `str` and aggregate operation is `sum` the result is all strings catenated. In the past this column was not included -- silently dropped.
* a non-numeric column that does not support the aggregation function now generates a runtime error. In the past it was silently dropped.

In an attempt to facilitate the upgrade, this rewrites uses of `agg("aggregate_func")` calls into `aggregate_func()`. Later this will enable using Pyre to detect places that requre explicit `numeric_only` argument to be compatible with Pandas-2.0.0. This is not a semantic change, the effect should be equivalent with the previous spelling.

This was generated with the following one-liner:
```
fbgr '\.agg\("[a-z]+"\)' -ls | xargs perl -pi -e 's,\.agg\("([a-z]+)"\),.\1(),'
arc f
```
Inspected all changes.

Differential Revision: D62195922
