### PR TITLE
[Trace format versioning] Step2: Add versioning to parserconfig

### DIFF
--- a/hta/common/trace_parser.py
+++ b/hta/common/trace_parser.py
@@ -22,12 +22,8 @@ import pandas as pd
 from hta.common.trace_symbol_table import TraceSymbolTable
 
 from hta.configs.config import logger
-from hta.configs.parser_config import (
-    AttributeSpec,
-    ParserBackend,
-    ParserConfig,
-    ValueType,
-)
+from hta.configs.default_values import ValueType
+from hta.configs.parser_config import AttributeSpec, ParserBackend, ParserConfig
 from hta.utils.utils import normalize_gpu_stream_numbers
 
 # from memory_profiler import profile

--- a/hta/configs/default_values.py
+++ b/hta/configs/default_values.py
@@ -2,7 +2,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import List
+from enum import Enum
+from typing import Dict, List, NamedTuple, Union
 
 # Default Paths
 DEFAULT_TRACE_DIR = "/tmp/trace"
@@ -14,3 +15,40 @@ DF_SYMBOL_COLUMNS: List[str] = ["cat", "name"]
 # Runtime configurations
 IS_DEBUG_ENABLED: bool = True
 MAX_NUM_PROCESSES: int = 32
+
+
+class ValueType(Enum):
+    """ValueType enumerates the possible data types for the attribute values."""
+
+    Int = 1
+    Float = 2
+    String = 3
+    Object = 4
+
+
+class AttributeSpec(NamedTuple):
+    """AttributeSpec specifies what an attribute looks like and how to parse it.
+
+    An AttributeSpec instance has the following fields:
+    + name: the column name used in the output dataframe.
+    + raw_name: the key used in args dict object in the original json trace.
+    + value_type: the expected data type for the values of the attribute.
+    + default_value: what value will be used for missing attribute values.
+    """
+
+    name: str
+    raw_name: str
+    value_type: ValueType
+    default_value: Union[int, float, str, object]
+
+
+class EventArgs(NamedTuple):
+    AVAILABLE_ARGS: Dict[str, AttributeSpec]
+    ARGS_INPUT_SHAPE: List[AttributeSpec]
+    ARGS_BANDWIDTH: List[AttributeSpec]
+    ARGS_SYNC: List[AttributeSpec]
+    ARGS_MINIMUM: List[AttributeSpec]
+    ARGS_COMPLETE: List[AttributeSpec]
+    ARGS_INFO: List[AttributeSpec]
+    ARGS_COMMUNICATION: List[AttributeSpec]
+    ARGS_DEFAULT: List[AttributeSpec]

--- a/hta/configs/event_args_formats/event_args_1.0.0.yaml
+++ b/hta/configs/event_args_formats/event_args_1.0.0.yaml
@@ -1,0 +1,208 @@
+version: 1.0.0
+
+AVAILABLE_ARGS:
+  index::ev_idx:
+    name: ev_idx
+    raw_name: Ev Idx
+    value_type: Int
+    default_value: -1
+  index::external_id:
+    name: external_id
+    raw_name: External id
+    value_type: Int
+    default_value: -1
+  cpu_op::concrete_inputs:
+    name: concrete_inputs
+    raw_name: Concrete Inputs
+    value_type: Object
+    default_value: "[]"
+  cpu_op::fwd_thread:
+    name: fwd_thread_id
+    raw_name: Fwd thread id
+    value_type: Int
+    default_value: -1
+  cpu_op::input_dims:
+    name: input_dims
+    raw_name: Input Dims
+    value_type: Object
+    default_value: "-1"
+  cpu_op::input_type:
+    name: input_type
+    raw_name: Input type
+    value_type: Object
+    default_value: "-1"
+  cpu_op::input_strides:
+    name: input_strides
+    raw_name: Input Strides
+    value_type: Object
+    default_value: "-1"
+  cpu_op::sequence_number:
+    name: sequence
+    raw_name: Sequence number
+    value_type: Int
+    default_value: -1
+  cpu_op::kernel_backend:
+    name: kernel_backend
+    raw_name: kernel_backend
+    value_type: String
+    default_value: ""
+  correlation::cbid:
+    name: cbid
+    raw_name: cbid
+    value_type: Int
+    default_value: -1
+  correlation::cpu_gpu:
+    name: correlation
+    raw_name: correlation
+    value_type: Int
+    default_value: -1
+  sm::blocks:
+    name: blocks_per_sm
+    raw_name: blocks per SM
+    value_type: Object
+    default_value: "[]"
+  sm::occupancy:
+    name: est_occupancy
+    raw_name: est. achieved occupancy %
+    value_type: Int
+    default_value: -1
+  sm::warps:
+    name: warps_per_sm
+    raw_name: warps per SM
+    value_type: Float
+    default_value: 0.0
+  data::bytes:
+    name: bytes
+    raw_name: bytes
+    value_type: Int
+    default_value: -1
+  data::bandwidth:
+    name: memory_bw_gbps
+    raw_name: memory bandwidth (GB/s)
+    value_type: Float
+    default_value: 0.0
+  cuda::context:
+    name: context
+    raw_name: context
+    value_type: Int
+    default_value: -1
+  cuda::device:
+    name: device
+    raw_name: device
+    value_type: Int
+    default_value: -1
+  cuda::stream:
+    name: stream
+    raw_name: stream
+    value_type: Int
+    default_value: -1
+  kernel::queued:
+    name: queued
+    raw_name: queued
+    value_type: Int
+    default_value: -1
+  kernel::shared_memory:
+    name: shared_memory
+    raw_name: shared memory
+    value_type: Int
+    default_value: -1
+  threads::block:
+    name: block
+    raw_name: block
+    value_type: Object
+    default_value: "[]"
+  threads::grid:
+    name: grid
+    raw_name: grid
+    value_type: Object
+    default_value: "[]"
+  threads::registers:
+    name: registers_per_thread
+    raw_name: registers per thread
+    value_type: Int
+    default_value: -1
+  cuda_sync::stream:
+    name: wait_on_stream
+    raw_name: wait_on_stream
+    value_type: Int
+    default_value: -1
+  cuda_sync::event:
+    name: wait_on_cuda_event_record_corr_id
+    raw_name: wait_on_cuda_event_record_corr_id
+    value_type: Int
+    default_value: -1
+  info::labels:
+    name: labels
+    raw_name: labels
+    value_type: String
+    default_value: ""
+  info::name:
+    name: name
+    raw_name: name
+    value_type: Int
+    default_value: -1
+  info::op_count:
+    name: op_count
+    raw_name: Op count
+    value_type: Int
+    default_value: -1
+  info::sort_index:
+    name: sort_index
+    raw_name: sort_index
+    value_type: Int
+    default_value: -1
+  nccl::collective_name:
+    name: collective_name
+    raw_name: Collective name
+    value_type: String
+    default_value: ""
+  nccl::in_msg_nelems:
+    name: in_msg_nelems
+    raw_name: In msg nelems
+    value_type: Int
+    default_value: 0
+  nccl::out_msg_nelems:
+    name: out_msg_nelems
+    raw_name: Out msg nelems
+    value_type: Int
+    default_value: 0
+  nccl::group_size:
+    name: group_size
+    raw_name: Group size
+    value_type: Int
+    default_value: 0
+  nccl::dtype:
+    name: msg_dtype
+    raw_name: dtype
+    value_type: String
+    default_value: ""
+  nccl::in_split_size:
+    name: in_split_size
+    raw_name: In split size
+    value_type: Object
+    default_value: "[]"
+  nccl::out_split_size:
+    name: out_split_size
+    raw_name: Out split size
+    value_type: Object
+    default_value: "[]"
+  nccl::process_group_name:
+    name: process_group_name
+    raw_name: Process Group Name
+    value_type: String
+    default_value: ""
+  nccl::process_group_desc:
+    name: process_group_desc
+    raw_name: Process Group Description
+    value_type: String
+    default_value: ""
+  nccl::process_group_ranks:
+    name: process_group_ranks
+    raw_name: Process Group Ranks
+    value_type: Object
+    default_value: "[]"
+  nccl::rank:
+    name: process_rank
+    raw_name: Rank
+    value_type: Int
+    default_value: -1

--- a/hta/configs/event_args_yaml_parser.py
+++ b/hta/configs/event_args_yaml_parser.py
@@ -1,0 +1,139 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+
+import importlib.resources
+import re
+from functools import lru_cache
+from typing import Callable, Dict, List, NamedTuple
+
+import yaml
+
+from hta.configs.default_values import AttributeSpec, EventArgs, ValueType
+
+
+class YamlVersion(NamedTuple):
+    major: int
+    minor: int
+    patch: int
+
+    def get_version_str(self) -> str:
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+    @staticmethod
+    def from_string(version_str: str) -> "YamlVersion":
+        pattern = r"^(\d+)\.(\d+)\.(\d+)$"
+        match = re.match(pattern, version_str)
+        if not match:
+            raise ValueError(f"Invalid version string: {version_str}")
+        major, minor, patch = map(int, match.groups())
+        return YamlVersion(major, minor, patch)
+
+
+# Yaml version will be mapped to the yaml files defined under the "event_args_formats" folder
+v1_0_0: YamlVersion = YamlVersion(1, 0, 0)
+
+
+ARGS_INPUT_SHAPE_FUNC: Callable[[Dict[str, AttributeSpec]], List[AttributeSpec]] = (
+    lambda available_args: [
+        available_args[k]
+        for k in ["cpu_op::input_dims", "cpu_op::input_type", "cpu_op::input_strides"]
+    ]
+)
+ARGS_BANDWIDTH_FUNC: Callable[[Dict[str, AttributeSpec]], List[AttributeSpec]] = (
+    lambda available_args: [
+        available_args[k] for k in ["data::bytes", "data::bandwidth"]
+    ]
+)
+ARGS_SYNC_FUNC: Callable[[Dict[str, AttributeSpec]], List[AttributeSpec]] = (
+    lambda available_args: [
+        available_args[k] for k in ["cuda_sync::stream", "cuda_sync::event"]
+    ]
+)
+ARGS_MINIMUM_FUNC: Callable[[Dict[str, AttributeSpec]], List[AttributeSpec]] = (
+    lambda available_args: [
+        available_args[k] for k in ["cuda::stream", "correlation::cpu_gpu"]
+    ]
+)
+ARGS_COMPLETE_FUNC: Callable[[Dict[str, AttributeSpec]], List[AttributeSpec]] = (
+    lambda available_args: [
+        available_args[k] for k in available_args if not k.startswith("info")
+    ]
+)
+ARGS_INFO_FUNC: Callable[[Dict[str, AttributeSpec]], List[AttributeSpec]] = (
+    lambda available_args: [
+        available_args[k] for k in ["info::labels", "info::name", "info::sort_index"]
+    ]
+)
+ARGS_COMMUNICATION_FUNC: Callable[[Dict[str, AttributeSpec]], List[AttributeSpec]] = (
+    lambda available_args: [
+        available_args[k]
+        for k in [
+            "nccl::collective_name",
+            "nccl::in_msg_nelems",
+            "nccl::out_msg_nelems",
+            "nccl::dtype",
+            "nccl::group_size",
+            "nccl::rank",
+            "nccl::in_split_size",
+            "nccl::out_split_size",
+        ]
+    ]
+)
+ARGS_DEFAULT_FUNC: Callable[[Dict[str, AttributeSpec]], List[AttributeSpec]] = (
+    lambda available_args: (
+        ARGS_MINIMUM_FUNC(available_args)
+        + ARGS_BANDWIDTH_FUNC(available_args)
+        + ARGS_SYNC_FUNC(available_args)
+        + ARGS_INPUT_SHAPE_FUNC(available_args)
+        + [available_args["index::external_id"]]
+    )
+)
+
+
+@lru_cache()
+def parse_event_args_yaml(version: YamlVersion) -> EventArgs:
+    local_yaml_data_filepath = str(
+        importlib.resources.files(__package__).joinpath(
+            f"event_args_{version.get_version_str()}.yaml",
+        )
+    )
+    with open(local_yaml_data_filepath, "r") as f:
+        yaml_content = yaml.safe_load(f)
+
+    def parse_value_type(value: str) -> ValueType:
+        return ValueType[value]
+
+    available_args: Dict[str, AttributeSpec] = {
+        k: AttributeSpec(
+            name=value["name"],
+            raw_name=value["raw_name"],
+            value_type=parse_value_type(value["value_type"]),
+            default_value=value["default_value"],
+        )
+        for k, value in yaml_content["AVAILABLE_ARGS"].items()
+    }
+
+    return EventArgs(
+        AVAILABLE_ARGS=available_args,
+        ARGS_INPUT_SHAPE=ARGS_INPUT_SHAPE_FUNC(available_args),
+        ARGS_BANDWIDTH=ARGS_BANDWIDTH_FUNC(available_args),
+        ARGS_SYNC=ARGS_SYNC_FUNC(available_args),
+        ARGS_MINIMUM=ARGS_MINIMUM_FUNC(available_args),
+        ARGS_COMPLETE=ARGS_COMPLETE_FUNC(available_args),
+        ARGS_INFO=ARGS_INFO_FUNC(available_args),
+        ARGS_COMMUNICATION=ARGS_COMMUNICATION_FUNC(available_args),
+        ARGS_DEFAULT=ARGS_DEFAULT_FUNC(available_args),
+    )
+
+
+def main() -> None:
+    version = v1_0_0
+    event_args = parse_event_args_yaml(version)
+    print(event_args)
+    print(f"Printed event args for version {version.get_version_str()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/hta/configs/parser_config.py
+++ b/hta/configs/parser_config.py
@@ -4,7 +4,12 @@ import copy
 from enum import Enum
 from typing import Dict, List, Optional, Set
 
-from hta.configs.default_values import AttributeSpec, ValueType
+from hta.configs.default_values import AttributeSpec, EventArgs
+from hta.configs.event_args_yaml_parser import (
+    parse_event_args_yaml,
+    v1_0_0,
+    YamlVersion,
+)
 
 
 class ParserBackend(str, Enum):
@@ -27,104 +32,9 @@ class TraceType(str, Enum):
     Inference = "inference"
 
 
-AVAILABLE_ARGS: Dict[str, AttributeSpec] = {
-    "index::ev_idx": AttributeSpec("ev_idx", "Ev Idx", ValueType.Int, -1),
-    "index::external_id": AttributeSpec(
-        "external_id", "External id", ValueType.Int, -1
-    ),
-    "cpu_op::concrete_inputs": AttributeSpec(
-        "concrete_inputs", "Concrete Inputs", ValueType.Object, "[]"
-    ),
-    "cpu_op::fwd_thread": AttributeSpec(
-        "fwd_thread_id", "Fwd thread id", ValueType.Int, -1
-    ),
-    "cpu_op::input_dims": AttributeSpec(
-        "input_dims", "Input Dims", ValueType.Object, "-1"
-    ),
-    "cpu_op::input_type": AttributeSpec(
-        "input_type", "Input type", ValueType.Object, "-1"
-    ),
-    "cpu_op::input_strides": AttributeSpec(
-        "input_strides",
-        "Input Strides",
-        ValueType.Object,
-        "-1",
-    ),
-    "cpu_op::sequence_number": AttributeSpec(
-        "sequence", "Sequence number", ValueType.Int, -1
-    ),
-    # kernel_backend, for example triton.
-    "cpu_op::kernel_backend": AttributeSpec(
-        "kernel_backend", "kernel_backend", ValueType.String, ""
-    ),
-    "correlation::cbid": AttributeSpec("cbid", "cbid", ValueType.Int, -1),
-    "correlation::cpu_gpu": AttributeSpec(
-        "correlation", "correlation", ValueType.Int, -1
-    ),
-    "sm::blocks": AttributeSpec(
-        "blocks_per_sm", "blocks per SM", ValueType.Object, "[]"
-    ),
-    "sm::occupancy": AttributeSpec(
-        "est_occupancy", "est. achieved occupancy %", ValueType.Int, -1
-    ),
-    "sm::warps": AttributeSpec("warps_per_sm", "warps per SM", ValueType.Float, 0.0),
-    "data::bytes": AttributeSpec("bytes", "bytes", ValueType.Int, -1),
-    "data::bandwidth": AttributeSpec(
-        "memory_bw_gbps", "memory bandwidth (GB/s)", ValueType.Float, 0.0
-    ),
-    "cuda::context": AttributeSpec("context", "context", ValueType.Int, -1),
-    "cuda::device": AttributeSpec("device", "device", ValueType.Int, -1),
-    "cuda::stream": AttributeSpec("stream", "stream", ValueType.Int, -1),
-    "kernel::queued": AttributeSpec("queued", "queued", ValueType.Int, -1),
-    "kernel::shared_memory": AttributeSpec(
-        "shared_memory", "shared memory", ValueType.Int, -1
-    ),
-    "threads::block": AttributeSpec("block", "block", ValueType.Object, "[]"),
-    "threads::grid": AttributeSpec("grid", "grid", ValueType.Object, "[]"),
-    "threads::registers": AttributeSpec(
-        "registers_per_thread", "registers per thread", ValueType.Int, -1
-    ),
-    "cuda_sync::stream": AttributeSpec(
-        "wait_on_stream", "wait_on_stream", ValueType.Int, -1
-    ),
-    "cuda_sync::event": AttributeSpec(
-        "wait_on_cuda_event_record_corr_id",
-        "wait_on_cuda_event_record_corr_id",
-        ValueType.Int,
-        -1,
-    ),
-    "info::labels": AttributeSpec("labels", "labels", ValueType.String, ""),
-    "info::name": AttributeSpec("name", "name", ValueType.Int, -1),
-    "info::op_count": AttributeSpec("op_count", "Op count", ValueType.Int, -1),
-    "info::sort_index": AttributeSpec("sort_index", "sort_index", ValueType.Int, -1),
-    "nccl::collective_name": AttributeSpec(
-        "collective_name", "Collective name", ValueType.String, ""
-    ),
-    "nccl::in_msg_nelems": AttributeSpec(
-        "in_msg_nelems", "In msg nelems", ValueType.Int, 0
-    ),
-    "nccl::out_msg_nelems": AttributeSpec(
-        "out_msg_nelems", "Out msg nelems", ValueType.Int, 0
-    ),
-    "nccl::group_size": AttributeSpec("group_size", "Group size", ValueType.Int, 0),
-    "nccl::dtype": AttributeSpec("msg_dtype", "dtype", ValueType.String, ""),
-    "nccl::in_split_size": AttributeSpec(
-        "in_split_size", "In split size", ValueType.Object, "[]"
-    ),
-    "nccl::out_split_size": AttributeSpec(
-        "out_split_size", "Out split size", ValueType.Object, "[]"
-    ),
-    "nccl::process_group_name": AttributeSpec(
-        "process_group_name", "Process Group Name", ValueType.String, ""
-    ),
-    "nccl::process_group_desc": AttributeSpec(
-        "process_group_desc", "Process Group Description", ValueType.String, ""
-    ),
-    "nccl::process_group_ranks": AttributeSpec(
-        "process_group_ranks", "Process Group Ranks", ValueType.Object, "[]"
-    ),
-    "nccl::rank": AttributeSpec("process_rank", "Rank", ValueType.Int, -1),
-}
+DEFAULT_PARSE_VERSION = v1_0_0
+DEFAULT_VER_EVENT_ARGS: EventArgs = parse_event_args_yaml(DEFAULT_PARSE_VERSION)
+AVAILABLE_ARGS: Dict[str, AttributeSpec] = DEFAULT_VER_EVENT_ARGS.AVAILABLE_ARGS
 
 
 class ParserConfig:
@@ -144,52 +54,24 @@ class ParserConfig:
     This class can be extended to support other customizations.
     """
 
-    ARGS_INPUT_SHAPE: List[AttributeSpec] = [
-        AVAILABLE_ARGS[k]
-        for k in ["cpu_op::input_dims", "cpu_op::input_type", "cpu_op::input_strides"]
-    ]
-    ARGS_BANDWIDTH: List[AttributeSpec] = [
-        AVAILABLE_ARGS[k] for k in ["data::bytes", "data::bandwidth"]
-    ]
-    ARGS_SYNC: List[AttributeSpec] = [
-        AVAILABLE_ARGS[k] for k in ["cuda_sync::stream", "cuda_sync::event"]
-    ]
-    ARGS_MINIMUM: List[AttributeSpec] = [
-        AVAILABLE_ARGS[k] for k in ["cuda::stream", "correlation::cpu_gpu"]
-    ]
-    ARGS_COMPLETE: List[AttributeSpec] = [
-        AVAILABLE_ARGS[k] for k in AVAILABLE_ARGS if not k.startswith("info")
-    ]
-    ARGS_INFO: List[AttributeSpec] = [
-        AVAILABLE_ARGS[k] for k in ["info::labels", "info::name", "info::sort_index"]
-    ]
-    ARGS_COMMUNICATION: List[AttributeSpec] = [
-        AVAILABLE_ARGS[k]
-        for k in [
-            "nccl::collective_name",
-            "nccl::in_msg_nelems",
-            "nccl::out_msg_nelems",
-            "nccl::dtype",
-            "nccl::group_size",
-            "nccl::rank",
-            "nccl::in_split_size",
-            "nccl::out_split_size",
-        ]
-    ]
-    ARGS_DEFAULT: List[AttributeSpec] = (
-        ARGS_MINIMUM
-        + ARGS_BANDWIDTH
-        + ARGS_SYNC
-        + ARGS_INPUT_SHAPE
-        + [AVAILABLE_ARGS["index::external_id"]]
-    )
+    ARGS_INPUT_SHAPE: List[AttributeSpec] = DEFAULT_VER_EVENT_ARGS.ARGS_INPUT_SHAPE
+    ARGS_BANDWIDTH: List[AttributeSpec] = DEFAULT_VER_EVENT_ARGS.ARGS_BANDWIDTH
+    ARGS_SYNC: List[AttributeSpec] = DEFAULT_VER_EVENT_ARGS.ARGS_SYNC
+    ARGS_MINIMUM: List[AttributeSpec] = DEFAULT_VER_EVENT_ARGS.ARGS_MINIMUM
+    ARGS_COMPLETE: List[AttributeSpec] = DEFAULT_VER_EVENT_ARGS.ARGS_COMPLETE
+    ARGS_INFO: List[AttributeSpec] = DEFAULT_VER_EVENT_ARGS.ARGS_INFO
+    ARGS_COMMUNICATION: List[AttributeSpec] = DEFAULT_VER_EVENT_ARGS.ARGS_COMMUNICATION
+    ARGS_DEFAULT: List[AttributeSpec] = DEFAULT_VER_EVENT_ARGS.ARGS_DEFAULT
 
     def __init__(
         self,
         args: Optional[List[AttributeSpec]] = None,
         user_provide_trace_type: Optional[TraceType] = None,
+        version: YamlVersion = DEFAULT_PARSE_VERSION,
     ) -> None:
-        self.args: List[AttributeSpec] = args if args else self.get_default_args()
+        self.args: List[AttributeSpec] = (
+            args if args else self.get_default_args(version=version)
+        )
         self.parser_backend: Optional[ParserBackend] = None
         self.trace_memory: bool = False
         self.user_provide_trace_type: Optional[TraceType] = user_provide_trace_type
@@ -199,20 +81,30 @@ class ParserConfig:
         return copy.deepcopy(_DEFAULT_PARSER_CONFIG)
 
     @classmethod
+    def get_versioned_cfg(cls, version: YamlVersion) -> "ParserConfig":
+        return copy.deepcopy(ParserConfig(version=version))
+
+    @classmethod
     def set_default_cfg(cls, cfg: "ParserConfig") -> None:
         _DEFAULT_PARSER_CONFIG.set_args(cfg.get_args())
 
     @classmethod
-    def get_minimum_args(cls) -> List[AttributeSpec]:
-        return cls.ARGS_MINIMUM.copy()
+    def get_minimum_args(
+        cls, version: YamlVersion = DEFAULT_PARSE_VERSION
+    ) -> List[AttributeSpec]:
+        return parse_event_args_yaml(version).ARGS_MINIMUM.copy()
 
     @classmethod
-    def get_default_args(cls) -> List[AttributeSpec]:
-        return cls.ARGS_DEFAULT.copy()
+    def get_default_args(
+        cls, version: YamlVersion = DEFAULT_PARSE_VERSION
+    ) -> List[AttributeSpec]:
+        return parse_event_args_yaml(version).ARGS_DEFAULT.copy()
 
     @classmethod
-    def get_info_args(cls) -> List[AttributeSpec]:
-        return cls.ARGS_INFO.copy()
+    def get_info_args(
+        cls, version: YamlVersion = DEFAULT_PARSE_VERSION
+    ) -> List[AttributeSpec]:
+        return parse_event_args_yaml(version).ARGS_INFO.copy()
 
     def set_args(self, args: List[AttributeSpec]) -> None:
         if args != self.args:
@@ -233,8 +125,29 @@ class ParserConfig:
         self.parser_backend = parser_backend
 
     @staticmethod
-    def enable_communication_args() -> None:
-        _DEFAULT_PARSER_CONFIG.add_args(ParserConfig.ARGS_COMMUNICATION)
+    def enable_communication_args(version: YamlVersion = DEFAULT_PARSE_VERSION) -> None:
+        _DEFAULT_PARSER_CONFIG.add_args(
+            parse_event_args_yaml(version).ARGS_COMMUNICATION
+        )
+
+    @staticmethod
+    def set_global_parser_config_version(version: YamlVersion) -> None:
+        global _DEFAULT_PARSER_CONFIG
+        _DEFAULT_PARSER_CONFIG = ParserConfig(version=version)
+
+        global AVAILABLE_ARGS
+        AVAILABLE_ARGS = parse_event_args_yaml(version).AVAILABLE_ARGS
+
+        ParserConfig.ARGS_INPUT_SHAPE = parse_event_args_yaml(version).ARGS_INPUT_SHAPE
+        ParserConfig.ARGS_BANDWIDTH = parse_event_args_yaml(version).ARGS_BANDWIDTH
+        ParserConfig.ARGS_SYNC = parse_event_args_yaml(version).ARGS_SYNC
+        ParserConfig.ARGS_MINIMUM = parse_event_args_yaml(version).ARGS_MINIMUM
+        ParserConfig.ARGS_COMPLETE = parse_event_args_yaml(version).ARGS_COMPLETE
+        ParserConfig.ARGS_INFO = parse_event_args_yaml(version).ARGS_INFO
+        ParserConfig.ARGS_COMMUNICATION = parse_event_args_yaml(
+            version
+        ).ARGS_COMMUNICATION
+        ParserConfig.ARGS_DEFAULT = parse_event_args_yaml(version).ARGS_DEFAULT
 
 
 # Define a global ParserConfig variable for internal use. To access this variable,

--- a/hta/configs/parser_config.py
+++ b/hta/configs/parser_config.py
@@ -2,7 +2,9 @@
 
 import copy
 from enum import Enum
-from typing import Dict, List, NamedTuple, Optional, Set, Union
+from typing import Dict, List, Optional, Set
+
+from hta.configs.default_values import AttributeSpec, ValueType
 
 
 class ParserBackend(str, Enum):
@@ -17,37 +19,12 @@ class ParserBackend(str, Enum):
     IJSON_BATCH_AND_COMPRESS = "ijson_batch_and_compress"
 
 
-class ValueType(Enum):
-    """ValueType enumerates the possible data types for the attribute values."""
-
-    Int = 1
-    Float = 2
-    String = 3
-    Object = 4
-
-
 class TraceType(str, Enum):
     """TraceType enumerates the possible trace types"""
 
     Training = "training"
     TrainingWoProfilerstepAnnot = "training_wo_profilerstep_annot"
     Inference = "inference"
-
-
-class AttributeSpec(NamedTuple):
-    """AttributeSpec specifies what an attribute looks like and how to parse it.
-
-    An AttributeSpec instance has the following fields:
-    + name: the column name used in the output dataframe.
-    + raw_name: the key used in args dict object in the original json trace.
-    + value_type: the expected data type for the values of the attribute.
-    + default_value: what value will be used for missing attribute values.
-    """
-
-    name: str
-    raw_name: str
-    value_type: ValueType
-    default_value: Union[int, float, str, object]
 
 
 AVAILABLE_ARGS: Dict[str, AttributeSpec] = {

--- a/hta/utils/validate_trace.py
+++ b/hta/utils/validate_trace.py
@@ -8,7 +8,8 @@ from typing import Any, Dict, List, Tuple
 
 import pandas as pd
 from hta.common.trace_file import read_trace
-from hta.configs.parser_config import AttributeSpec, ParserConfig, ValueType
+from hta.configs.default_values import ValueType
+from hta.configs.parser_config import AttributeSpec, ParserConfig
 
 
 def get_argument_spec(level: str = "default") -> List[AttributeSpec]:


### PR DESCRIPTION
This PR has a dependency on https://github.com/facebookresearch/HolisticTraceAnalysis/pull/187

Summary:
- Add versioning to ParserConfig. 
- Use the event args yaml parser to read out the versioned event args.

Differential Revision: D64116676


