### PR TITLE
Fix HTA OSS CI errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: ufmt
         additional_dependencies:
           - toml
-          - black == 22.8.0
+          - black == 24.3.0
           - usort == 1.0.4
 
 -   repo: https://github.com/pycqa/flake8
@@ -29,8 +29,8 @@ repos:
         args: [--show-source, --statistics]
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.971'
+    rev: 'v1.2.0'
     hooks:
     -   id: mypy
-        args: [--no-strict-optional, --ignore-missing-imports, --scripts-are-modules, --pretty]
-        additional_dependencies: [numpy==1.21.5]
+        args: [--no-strict-optional, --ignore-missing-imports, --explicit-package-bases, --scripts-are-modules, --pretty]
+        additional_dependencies: [numpy==1.23.5, types-requests]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 #### Added
+- Update pyproject.toml to workaround missing stub packages for yaml.
 - Add trace format validator
 - Added multiple trace filter classes and demos.
 - Added enhanced trace call stack graph implementation.

--- a/hta/configs/event_args_yaml_parser.py
+++ b/hta/configs/event_args_yaml_parser.py
@@ -3,9 +3,9 @@
 # pyre-strict
 
 
-import importlib.resources
 import re
 from functools import lru_cache
+from pathlib import Path
 from typing import Callable, Dict, List, NamedTuple
 
 import yaml
@@ -94,11 +94,10 @@ ARGS_DEFAULT_FUNC: Callable[[Dict[str, AttributeSpec]], List[AttributeSpec]] = (
 
 @lru_cache()
 def parse_event_args_yaml(version: YamlVersion) -> EventArgs:
-    local_yaml_data_filepath = str(
-        importlib.resources.files(__package__).joinpath(
-            f"event_args_{version.get_version_str()}.yaml",
-        )
-    )
+    pkg_path: Path = Path(__file__).parent
+    yaml_file = f"event_args_{version.get_version_str()}.yaml"
+    local_yaml_data_filepath = str(pkg_path.joinpath("event_args_formats", yaml_file))
+
     with open(local_yaml_data_filepath, "r") as f:
         yaml_content = yaml.safe_load(f)
 

--- a/hta/configs/parser_config.py
+++ b/hta/configs/parser_config.py
@@ -32,7 +32,7 @@ class TraceType(str, Enum):
     Inference = "inference"
 
 
-DEFAULT_PARSE_VERSION = v1_0_0
+DEFAULT_PARSE_VERSION: YamlVersion = v1_0_0
 DEFAULT_VER_EVENT_ARGS: EventArgs = parse_event_args_yaml(DEFAULT_PARSE_VERSION)
 AVAILABLE_ARGS: Dict[str, AttributeSpec] = DEFAULT_VER_EVENT_ARGS.AVAILABLE_ARGS
 

--- a/hta/utils/validate_trace.py
+++ b/hta/utils/validate_trace.py
@@ -117,6 +117,7 @@ def _check_args(
                     and isinstance(arg_value, float)
                 ):
                     continue
+
                 type_violations[k] = (
                     f"key={k}: value={v} type={type(v)}; expect_type='{arg_type.name}' default_value={arg_value}"
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,7 @@ include_trailing_comma = true
 use_parentheses = true
 src_paths = ["hta", "tests"]
 skip_glob = ["examples/*"]
+
+[[tool.mypy.overrides]]
+module = "yaml"
+ignore_missing_imports = true


### PR DESCRIPTION
Summary:
Fix HTA OSS CI errors. 

This diff is a dup of D64839500. We can't directly work on D64839500 because commandeering a diff caused OSS sync stopped working.

Differential Revision: D64934436


