### PR TITLE
categorize "dma_request" as mem kernel

### DIFF
--- a/hta/utils/utils.py
+++ b/hta/utils/utils.py
@@ -76,7 +76,8 @@ def is_memory_kernel(name: str) -> bool:
     Returns:
         A boolean indicating if the kernel is an IO kernel.
     """
-    return "Memcpy" in name or "Memset" in name
+    memory_kernel_pattern = re.compile(r"(^Memcpy)|(^Memset)|(^dma)")
+    return memory_kernel_pattern.match(name) is not None
 
 
 def is_compute_kernel(name: str) -> bool:


### PR DESCRIPTION
Summary:
This diff enables kernel breakdown analysis for MTIA.
The memory events in MTIA are represented by dma_request. Add that condition to HTA to distinguish that kernel as memset kernel

Differential Revision: D65502770


