### PR TITLE
queue length for MTIA

### DIFF
--- a/hta/common/trace_symbol_table.py
+++ b/hta/common/trace_symbol_table.py
@@ -141,11 +141,13 @@ class TraceSymbolTable:
         cuLaunchKernel_id = self.sym_index.get("cuLaunchKernel", self.NULL)
         cudaMemcpyAsync_id = self.sym_index.get("cudaMemcpyAsync", self.NULL)
         cudaMemsetAsync_id = self.sym_index.get("cudaMemsetAsync", self.NULL)
-
+        mtiaLaunchKernel_id = self.sym_index.get(
+            "runFunction - job_prep_and_submit_for_execution", self.NULL
+        )
         return (
             f"((name == {cudaMemsetAsync_id}) or (name == {cudaMemcpyAsync_id}) or "
             f" (name == {cudaLaunchKernel_id}) or (name == {cudaLaunchKernelExC_id})"
-            f" or (name == {cuLaunchKernel_id})) and (index_correlation > 0)"
+            f" or (name == {cuLaunchKernel_id}) or (name == {mtiaLaunchKernel_id})) and (index_correlation > 0)"
         )
 
 


### PR DESCRIPTION
Summary: HTA computes the number of outstanding operations on each stream and is represented by queue length. It generates another trace with the queue length info

Differential Revision: D65774955


