### PR TITLE
add GPU kernel breakdown by user annotation range

### DIFF
--- a/examples/trace_analysis_demo.ipynb
+++ b/examples/trace_analysis_demo.ipynb
@@ -24,30 +24,49 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 8,
    "id": "c8e32f5d",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-08-22 11:27:02,545 - hta - trace.py:L329 - INFO - /Users/bcoutinho/Work/hta/queue_full_data\n",
-      "2024-08-22 11:27:02,561 - hta - trace_file.py:L102 - INFO - Rank to trace file map:\n",
-      "{1: '/Users/bcoutinho/Work/hta/queue_full_data/rank-1.Apr_10_22_19_54.3461.pt.trace.json.gz'}\n",
-      "2024-08-22 11:27:02,561 - hta - trace.py:L501 - INFO - ranks=[1]\n",
-      "2024-08-22 11:27:04,596 - hta - trace_parser.py:L111 - WARNING - Parsed /Users/bcoutinho/Work/hta/queue_full_data/rank-1.Apr_10_22_19_54.3461.pt.trace.json.gz time = 2.03 seconds \n",
-      "2024-08-22 11:27:06,097 - hta - trace_parser.py:L446 - WARNING - Parsed /Users/bcoutinho/Work/hta/queue_full_data/rank-1.Apr_10_22_19_54.3461.pt.trace.json.gz backend=json in 3.53 seconds; current PID:26558\n",
-      "2024-08-22 11:27:06,841 - hta - trace.py:L236 - WARNING - Overall parsing of /Users/bcoutinho/Work/hta/queue_full_data/rank-1.Apr_10_22_19_54.3461.pt.trace.json.gz in 4.28 seconds; current PID:26558\n",
-      "2024-08-22 11:27:06,934 - hta - trace.py:L475 - WARNING - leaving parse_multiple_ranks duration=4.37 seconds\n",
-      "2024-08-22 11:27:06,935 - hta - trace.py:L513 - WARNING - leaving parse_traces duration=4.37 seconds\n"
+      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-1.json.gz time = 2.75 seconds \n",
+      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-0.json.gz time = 2.76 seconds \n",
+      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-4.json.gz time = 2.76 seconds \n",
+      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-6.json.gz time = 2.77 seconds \n",
+      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-2.json.gz time = 2.79 seconds \n",
+      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-3.json.gz time = 2.80 seconds \n",
+      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-5.json.gz time = 2.81 seconds \n",
+      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-7.json.gz time = 2.81 seconds \n",
+      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-1.json.gz backend=json in 31.48 seconds; current PID:43921\n",
+      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-0.json.gz backend=json in 31.76 seconds; current PID:43920\n",
+      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-6.json.gz backend=json in 32.65 seconds; current PID:43926\n",
+      "Overall parsing of /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-1.json.gz in 32.67 seconds; current PID:43921\n",
+      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-4.json.gz backend=json in 32.89 seconds; current PID:43924\n",
+      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-2.json.gz backend=json in 32.98 seconds; current PID:43922\n",
+      "Overall parsing of /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-0.json.gz in 33.13 seconds; current PID:43920\n",
+      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-5.json.gz backend=json in 33.49 seconds; current PID:43925\n",
+      "Overall parsing of /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-6.json.gz in 34.19 seconds; current PID:43926\n",
+      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-7.json.gz backend=json in 34.27 seconds; current PID:43927\n",
+      "Overall parsing of /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-4.json.gz in 34.33 seconds; current PID:43924\n",
+      "Overall parsing of /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-2.json.gz in 34.40 seconds; current PID:43922\n",
+      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-3.json.gz backend=json in 34.54 seconds; current PID:43923\n",
+      "Overall parsing of /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-5.json.gz in 35.08 seconds; current PID:43925\n",
+      "Overall parsing of /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-7.json.gz in 35.82 seconds; current PID:43927\n",
+      "Overall parsing of /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-3.json.gz in 36.20 seconds; current PID:43923\n",
+      "leaving parse_multiple_ranks duration=43.52 seconds\n",
+      "leaving parse_traces duration=43.52 seconds\n"
      ]
     }
    ],
    "source": [
     "from hta.trace_analysis import TraceAnalysis\n",
     "\n",
-    "trace_dir = \"~/HolisticTraceAnalysis2/tests/data/vision_transformer/\"\n",
+    "hta_dir = \"<PATH TO HTA>\"\n",
+    "hta_dir = \"~/Work/hta/HolisticTraceAnalysis2/\"\n",
+    "trace_dir = hta_dir + \"/tests/data/vision_transformer/\"\n",
     "analyzer = TraceAnalysis(trace_dir=trace_dir)"
    ]
   },
@@ -435,7 +454,9 @@
    "cell_type": "code",
    "execution_count": 6,
    "id": "8b27ec2d",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "data": {
@@ -632,6 +653,298 @@
    ],
    "source": [
     "kernel_metrics_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c18b2cba-8fea-4270-a780-25b83f6c1cd9",
+   "metadata": {},
+   "source": [
+    "## Kernel Attribution to Annotations\n",
+    "\n",
+    "### Description\n",
+    "\n",
+    "The PyTorch profile supports user marked annotations that can provide context on which module/component a kernel belongs to. This feature associates these user annoations to GPU kernels. The function returns a full dataframe of all gpu kernels; the user can perform aggregations on top of this.\n",
+    "\n",
+    "### API"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "291a2ead-9904-43ab-a0b5-ca9d36a1cb48",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mSignature:\u001b[0m\n",
+       "\u001b[0manalyzer\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_gpu_kernels_with_user_annotations\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mrank\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mint\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mexpand_names\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mbool\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mshortern_names\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mbool\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m->\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mpandas\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcore\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mframe\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mDataFrame\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mDocstring:\u001b[0m\n",
+       "Provides a complete dataframe of GPU kernels and matches them to the corresponding user annotation i.e. user provided training phase. The output is a dataframe with all GPU kernel data alongside a \"user_annotation\" column.\n",
+       "\n",
+       "Args:\n",
+       "    rank (int): Specify rank to return GPU kernels for.\n",
+       "    expand_names (bool): Expand integer name value to full names. This will add\n",
+       "        the columns \"s_name\" and \"s_user_annotation\" to the dataframe.\n",
+       "    shortern_names (bool): When expand_names is True, this flag enables shortening\n",
+       "        large CUDA kernel names. This works by removing the '<' template paramters etc.\n",
+       "\n",
+       "Returns:\n",
+       "    pd.Dataframe:\n",
+       "        The returned dataframe has all trace columns along with \"user_annotation\",\n",
+       "        and optionally \"s_user_annotation\" column if expand_names=True.\n",
+       "\n",
+       "Note: This API is per rank, and does not have any visualization aspect.\n",
+       "\u001b[0;31mFile:\u001b[0m      ~/Work/hta/HolisticTraceAnalysis2/hta/trace_analysis.py\n",
+       "\u001b[0;31mType:\u001b[0m      method"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "analyzer.get_gpu_kernels_with_user_annotations?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe65f7d1-fbfe-4b12-af66-cf87262efb49",
+   "metadata": {},
+   "source": [
+    "Note:\n",
+    "1. When there are multiple user annoations associated to a kernel, we currently attribute to the lowest annoation in the stack. A future improvement is to also suport a stack column.\n",
+    "1. Currently, the user must specify a rank to get annoatated GPU kernel data for."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d40c4c2-87a2-4897-8cd3-e7da3eaf3be9",
+   "metadata": {},
+   "source": [
+    "### Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "fc507836-ba3b-44cf-9a3b-eb31ea55284c",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/ns_resolution_trace/rank-0.Apr_03_18_51_38.1102.pt.trace.json.gz time = 0.16 seconds \n",
+      "Rounding down ns resolution events due to issue with events overlapping. ts dtype = float64, dur dtype = float64.Please see https://github.com/pytorch/pytorch/pull/122425\n",
+      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/ns_resolution_trace/rank-0.Apr_03_18_51_38.1102.pt.trace.json.gz backend=json in 0.70 seconds; current PID:42089\n",
+      "Overall parsing of /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/ns_resolution_trace/rank-0.Apr_03_18_51_38.1102.pt.trace.json.gz in 0.90 seconds; current PID:42089\n",
+      "leaving parse_multiple_ranks duration=0.92 seconds\n",
+      "leaving parse_traces duration=0.92 seconds\n"
+     ]
+    }
+   ],
+   "source": [
+    "# This example uses a different trace that has user annotations\n",
+    "\n",
+    "trace_dir_user_anno = hta_dir + \"/tests/data/ns_resolution_trace/\"\n",
+    "analyzer_user_anno = TraceAnalysis(trace_dir=trace_dir_user_anno)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "d1d5032d-d070-4467-94ea-7074e50587ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gpu_kernels_df = analyzer_user_anno.get_gpu_kernels_with_user_annotations(rank=0, expand_names=True, shortern_names=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "9adf58d7-2df2-403e-8871-80991fa737bf",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>s_name</th>\n",
+       "      <th>s_cat</th>\n",
+       "      <th>s_user_annotation</th>\n",
+       "      <th>stream</th>\n",
+       "      <th>ts</th>\n",
+       "      <th>dur</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>void at::native::(anonymous namespace)::CatArr...</td>\n",
+       "      <td>kernel</td>\n",
+       "      <td>DistributedDataParallel.forward</td>\n",
+       "      <td>7</td>\n",
+       "      <td>3488</td>\n",
+       "      <td>5.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>void at::native::(anonymous namespace)::CatArr...</td>\n",
+       "      <td>kernel</td>\n",
+       "      <td>DistributedDataParallel.forward</td>\n",
+       "      <td>7</td>\n",
+       "      <td>3678</td>\n",
+       "      <td>2.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Memcpy DtoD (Device -&gt; Device)</td>\n",
+       "      <td>gpu_memcpy</td>\n",
+       "      <td>DistributedDataParallel.forward</td>\n",
+       "      <td>7</td>\n",
+       "      <td>4067</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Memcpy DtoD (Device -&gt; Device)</td>\n",
+       "      <td>gpu_memcpy</td>\n",
+       "      <td>DistributedDataParallel.forward</td>\n",
+       "      <td>7</td>\n",
+       "      <td>4081</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Memcpy DtoD (Device -&gt; Device)</td>\n",
+       "      <td>gpu_memcpy</td>\n",
+       "      <td>DistributedDataParallel.forward</td>\n",
+       "      <td>7</td>\n",
+       "      <td>4090</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4871</th>\n",
+       "      <td>void at::native::(anonymous namespace)::multi_...</td>\n",
+       "      <td>kernel</td>\n",
+       "      <td>void cudnn::cnn::reduce_wgrad_nchw_helper&lt;floa...</td>\n",
+       "      <td>7</td>\n",
+       "      <td>387344</td>\n",
+       "      <td>114.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4872</th>\n",
+       "      <td>void at::native::(anonymous namespace)::multi_...</td>\n",
+       "      <td>kernel</td>\n",
+       "      <td>void cudnn::cnn::reduce_wgrad_nchw_helper&lt;floa...</td>\n",
+       "      <td>7</td>\n",
+       "      <td>387460</td>\n",
+       "      <td>262.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4873</th>\n",
+       "      <td>void at::native::(anonymous namespace)::multi_...</td>\n",
+       "      <td>kernel</td>\n",
+       "      <td>void cudnn::cnn::reduce_wgrad_nchw_helper&lt;floa...</td>\n",
+       "      <td>7</td>\n",
+       "      <td>387724</td>\n",
+       "      <td>31.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4874</th>\n",
+       "      <td>void at::native::(anonymous namespace)::multi_...</td>\n",
+       "      <td>kernel</td>\n",
+       "      <td>void cudnn::cnn::reduce_wgrad_nchw_helper&lt;floa...</td>\n",
+       "      <td>7</td>\n",
+       "      <td>387756</td>\n",
+       "      <td>112.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4875</th>\n",
+       "      <td>void at::native::(anonymous namespace)::multi_...</td>\n",
+       "      <td>kernel</td>\n",
+       "      <td>void cudnn::cnn::reduce_wgrad_nchw_helper&lt;floa...</td>\n",
+       "      <td>7</td>\n",
+       "      <td>387870</td>\n",
+       "      <td>252.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>4876 rows × 6 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                 s_name       s_cat  \\\n",
+       "0     void at::native::(anonymous namespace)::CatArr...      kernel   \n",
+       "1     void at::native::(anonymous namespace)::CatArr...      kernel   \n",
+       "2                        Memcpy DtoD (Device -> Device)  gpu_memcpy   \n",
+       "3                        Memcpy DtoD (Device -> Device)  gpu_memcpy   \n",
+       "4                        Memcpy DtoD (Device -> Device)  gpu_memcpy   \n",
+       "...                                                 ...         ...   \n",
+       "4871  void at::native::(anonymous namespace)::multi_...      kernel   \n",
+       "4872  void at::native::(anonymous namespace)::multi_...      kernel   \n",
+       "4873  void at::native::(anonymous namespace)::multi_...      kernel   \n",
+       "4874  void at::native::(anonymous namespace)::multi_...      kernel   \n",
+       "4875  void at::native::(anonymous namespace)::multi_...      kernel   \n",
+       "\n",
+       "                                      s_user_annotation  stream      ts    dur  \n",
+       "0                       DistributedDataParallel.forward       7    3488    5.0  \n",
+       "1                       DistributedDataParallel.forward       7    3678    2.0  \n",
+       "2                       DistributedDataParallel.forward       7    4067    0.0  \n",
+       "3                       DistributedDataParallel.forward       7    4081    0.0  \n",
+       "4                       DistributedDataParallel.forward       7    4090    1.0  \n",
+       "...                                                 ...     ...     ...    ...  \n",
+       "4871  void cudnn::cnn::reduce_wgrad_nchw_helper<floa...       7  387344  114.0  \n",
+       "4872  void cudnn::cnn::reduce_wgrad_nchw_helper<floa...       7  387460  262.0  \n",
+       "4873  void cudnn::cnn::reduce_wgrad_nchw_helper<floa...       7  387724   31.0  \n",
+       "4874  void cudnn::cnn::reduce_wgrad_nchw_helper<floa...       7  387756  112.0  \n",
+       "4875  void cudnn::cnn::reduce_wgrad_nchw_helper<floa...       7  387870  252.0  \n",
+       "\n",
+       "[4876 rows x 6 columns]"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gpu_kernels_df[[\"s_name\", \"s_cat\", \"s_user_annotation\", \"stream\", \"ts\", \"dur\"]]"
    ]
   },
   {
@@ -2191,7 +2504,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.17"
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,

--- a/examples/trace_analysis_demo.ipynb
+++ b/examples/trace_analysis_demo.ipynb
@@ -24,48 +24,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "c8e32f5d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-1.json.gz time = 2.75 seconds \n",
-      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-0.json.gz time = 2.76 seconds \n",
-      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-4.json.gz time = 2.76 seconds \n",
-      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-6.json.gz time = 2.77 seconds \n",
-      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-2.json.gz time = 2.79 seconds \n",
-      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-3.json.gz time = 2.80 seconds \n",
-      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-5.json.gz time = 2.81 seconds \n",
-      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-7.json.gz time = 2.81 seconds \n",
-      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-1.json.gz backend=json in 31.48 seconds; current PID:43921\n",
-      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-0.json.gz backend=json in 31.76 seconds; current PID:43920\n",
-      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-6.json.gz backend=json in 32.65 seconds; current PID:43926\n",
-      "Overall parsing of /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-1.json.gz in 32.67 seconds; current PID:43921\n",
-      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-4.json.gz backend=json in 32.89 seconds; current PID:43924\n",
-      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-2.json.gz backend=json in 32.98 seconds; current PID:43922\n",
-      "Overall parsing of /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-0.json.gz in 33.13 seconds; current PID:43920\n",
-      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-5.json.gz backend=json in 33.49 seconds; current PID:43925\n",
-      "Overall parsing of /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-6.json.gz in 34.19 seconds; current PID:43926\n",
-      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-7.json.gz backend=json in 34.27 seconds; current PID:43927\n",
-      "Overall parsing of /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-4.json.gz in 34.33 seconds; current PID:43924\n",
-      "Overall parsing of /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-2.json.gz in 34.40 seconds; current PID:43922\n",
-      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-3.json.gz backend=json in 34.54 seconds; current PID:43923\n",
-      "Overall parsing of /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-5.json.gz in 35.08 seconds; current PID:43925\n",
-      "Overall parsing of /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-7.json.gz in 35.82 seconds; current PID:43927\n",
-      "Overall parsing of /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/vision_transformer/rank-3.json.gz in 36.20 seconds; current PID:43923\n",
-      "leaving parse_multiple_ranks duration=43.52 seconds\n",
-      "leaving parse_traces duration=43.52 seconds\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from hta.trace_analysis import TraceAnalysis\n",
     "\n",
     "hta_dir = \"<PATH TO HTA>\"\n",
-    "hta_dir = \"~/Work/hta/HolisticTraceAnalysis2/\"\n",
     "trace_dir = hta_dir + \"/tests/data/vision_transformer/\"\n",
     "analyzer = TraceAnalysis(trace_dir=trace_dir)"
    ]
@@ -732,25 +698,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "fc507836-ba3b-44cf-9a3b-eb31ea55284c",
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/ns_resolution_trace/rank-0.Apr_03_18_51_38.1102.pt.trace.json.gz time = 0.16 seconds \n",
-      "Rounding down ns resolution events due to issue with events overlapping. ts dtype = float64, dur dtype = float64.Please see https://github.com/pytorch/pytorch/pull/122425\n",
-      "Parsed /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/ns_resolution_trace/rank-0.Apr_03_18_51_38.1102.pt.trace.json.gz backend=json in 0.70 seconds; current PID:42089\n",
-      "Overall parsing of /Users/bcoutinho/Work/hta/HolisticTraceAnalysis2/tests/data/ns_resolution_trace/rank-0.Apr_03_18_51_38.1102.pt.trace.json.gz in 0.90 seconds; current PID:42089\n",
-      "leaving parse_multiple_ranks duration=0.92 seconds\n",
-      "leaving parse_traces duration=0.92 seconds\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# This example uses a different trace that has user annotations\n",
     "\n",
@@ -760,7 +713,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 24,
    "id": "d1d5032d-d070-4467-94ea-7074e50587ad",
    "metadata": {},
    "outputs": [],
@@ -770,7 +723,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 25,
    "id": "9adf58d7-2df2-403e-8871-80991fa737bf",
    "metadata": {},
    "outputs": [
@@ -938,7 +891,7 @@
        "[4876 rows x 6 columns]"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/hta/analyzers/breakdown_analysis.py
+++ b/hta/analyzers/breakdown_analysis.py
@@ -275,7 +275,9 @@ class BreakdownAnalysis:
                 gpu_kernels_df.loc[overlaps, "user_annotation"] = anno_name
 
         if expand_names:
-            decode_symbol_id_to_symbol_name(gpu_kernels_df, t.symbol_table, shortern_names)
+            decode_symbol_id_to_symbol_name(
+                gpu_kernels_df, t.symbol_table, shortern_names
+            )
 
         return gpu_kernels_df.reset_index(drop=True)
 

--- a/hta/analyzers/breakdown_analysis.py
+++ b/hta/analyzers/breakdown_analysis.py
@@ -259,10 +259,10 @@ class BreakdownAnalysis:
 
         for p in pid_tids:
             pid, tid = p["pid"], p["tid"]
-            gpu_kernels_df_filt = gpu_kernels_df.query(f"pid == {pid} and tid == {tid}")
             gpu_user_anno_df_filt = gpu_user_anno_df.query(
                 f"pid == {pid} and tid == {tid}"
             )
+            gpu_kernels_df_filt = gpu_kernels_df.query(f"pid == {pid} and tid == {tid}")
             logger.info(
                 f"Pid,tid = {p}, Num gpu kernels = {len(gpu_kernels_df_filt)}, Num gpu annotations = {len(gpu_user_anno_df_filt)}"
             )
@@ -272,7 +272,12 @@ class BreakdownAnalysis:
             for row in gpu_user_anno_df_filt.itertuples():
                 interval, anno_name = row.Index, row.name
                 overlaps = gpu_kernels_intervals.overlaps(interval)
-                gpu_kernels_df.loc[overlaps, "user_annotation"] = anno_name
+                gpu_kernels_df.loc[
+                    (gpu_kernels_df["pid"] == pid)
+                    & (gpu_kernels_df["tid"] == tid)
+                    & overlaps,
+                    "user_annotation",
+                ] = anno_name
 
         if expand_names:
             decode_symbol_id_to_symbol_name(

--- a/hta/common/trace_symbol_table.py
+++ b/hta/common/trace_symbol_table.py
@@ -162,3 +162,5 @@ def decode_symbol_id_to_symbol_name(
         df["s_name"] = df["name"].apply(lambda idx: s_tab[idx])
     if "cat" in df.columns and df["cat"].dtype.kind == "i":
         df["s_cat"] = df["cat"].apply(lambda idx: s_tab[idx])
+    if "user_annotation" in df.columns and df["user_annotation"].dtype.kind == "i":
+        df["s_user_annotation"] = df["user_annotation"].apply(lambda idx: s_tab[idx])

--- a/hta/common/trace_symbol_table.py
+++ b/hta/common/trace_symbol_table.py
@@ -158,9 +158,13 @@ def decode_symbol_id_to_symbol_name(
     s_tab: List[str] = symbol_table.sym_table
     if use_shorten_name:
         s_tab = [shorten_name(s) for s in s_tab]
+
+    def get_sym(idx):
+        return s_tab[idx] if idx >= 0 else ""
+
     if "name" in df.columns and df["name"].dtype.kind == "i":
-        df["s_name"] = df["name"].apply(lambda idx: s_tab[idx])
+        df["s_name"] = df["name"].apply(lambda idx: get_sym(idx))
     if "cat" in df.columns and df["cat"].dtype.kind == "i":
-        df["s_cat"] = df["cat"].apply(lambda idx: s_tab[idx])
+        df["s_cat"] = df["cat"].apply(lambda idx: get_sym(idx))
     if "user_annotation" in df.columns and df["user_annotation"].dtype.kind == "i":
-        df["s_user_annotation"] = df["user_annotation"].apply(lambda idx: s_tab[idx])
+        df["s_user_annotation"] = df["user_annotation"].apply(lambda idx: get_sym(idx))

--- a/hta/trace_analysis.py
+++ b/hta/trace_analysis.py
@@ -169,7 +169,7 @@ class TraceAnalysis:
             expand_names (bool): Expand integer name value to full names. This will add
                 the columns "s_name" and "s_user_annotation" to the dataframe.
             shortern_names (bool): When expand_names is True, this flag enables shortening
-                large CUDA kernel names. This works by removing the '<' template paramters etc.
+                large CUDA kernel names. This works by removing the '<' template parameters etc.
 
         Returns:
             pd.Dataframe:

--- a/hta/trace_analysis.py
+++ b/hta/trace_analysis.py
@@ -155,6 +155,31 @@ class TraceAnalysis:
             image_renderer,
         )
 
+    def get_gpu_kernels_with_user_annotations(
+        cls,
+        t: "Trace",
+        rank: int,
+        expand_names: bool = True,
+        shortern_names: bool = True,
+    ) -> Optional[pd.DataFrame]:
+        r"""
+        Provides a full dataframe of GPU kernels and matches them to the corresponding user annotation i.e. user provided training phase. The output is a dataframe with all GPU kernel data alongside a "user_annotation" column.
+
+        Args:
+            rank (int): Specify rank to return GPU kernels for.
+            expand_names (bool): Expand integer name value to full names. This will add
+                the columns "s_name" and "s_user_annotation" to the dataframe.
+            shortern_names (bool): When expand_names is True, this flag enables shortening
+                large CUDA kernel names. This works by removing the '<' template paramters etc.
+
+        Returns:
+            pd.Dataframe:
+                The returned dataframe has all trace columns along with "user_annotation", 
+                and optionally "s_user_annotation" column.
+
+        Note: This API is per rank, and does not have any visualization components
+        """
+
     def get_temporal_breakdown(self, visualize: bool = True) -> pd.DataFrame:
         r"""
         Compute the idle time, compute time and non-compute time for each rank. Time is measured in

--- a/hta/trace_analysis.py
+++ b/hta/trace_analysis.py
@@ -156,14 +156,13 @@ class TraceAnalysis:
         )
 
     def get_gpu_kernels_with_user_annotations(
-        cls,
-        t: "Trace",
+        self,
         rank: int,
         expand_names: bool = True,
         shortern_names: bool = True,
     ) -> Optional[pd.DataFrame]:
         r"""
-        Provides a full dataframe of GPU kernels and matches them to the corresponding user annotation i.e. user provided training phase. The output is a dataframe with all GPU kernel data alongside a "user_annotation" column.
+        Provides a complete dataframe of GPU kernels and matches them to the corresponding user annotation i.e. user provided training phase. The output is a dataframe with all GPU kernel data alongside a "user_annotation" column.
 
         Args:
             rank (int): Specify rank to return GPU kernels for.
@@ -174,11 +173,17 @@ class TraceAnalysis:
 
         Returns:
             pd.Dataframe:
-                The returned dataframe has all trace columns along with "user_annotation", 
-                and optionally "s_user_annotation" column.
+                The returned dataframe has all trace columns along with "user_annotation",
+                and optionally "s_user_annotation" column if expand_names=True.
 
-        Note: This API is per rank, and does not have any visualization components
+        Note: This API is per rank, and does not have any visualization aspect.
         """
+        return BreakdownAnalysis.get_gpu_kernels_with_user_annotations(
+            self.t,
+            rank,
+            expand_names,
+            shortern_names,
+        )
 
     def get_temporal_breakdown(self, visualize: bool = True) -> pd.DataFrame:
         r"""

--- a/hta/utils/utils.py
+++ b/hta/utils/utils.py
@@ -151,14 +151,15 @@ def shorten_name(name: str) -> str:
     This utility removes the functional arguments, template arguments, and return values
     to make the name easy to understand.
     """
-    if name.find("") < 0 and name.find("(") < 0:
+    if MEMORY_KERNEL_RE.match(name) is not None:
+        return name
+
     if name.find("<") < 0 and name.find("(") < 0:
         return name
 
     s: str = name.replace("->", "")
     stack: List[str] = []
     for c in s:
-        print(c)
         if c == ">":  # match generic template arguments
             while len(stack) and stack[-1] != "<":
                 stack.pop()
@@ -170,7 +171,6 @@ def shorten_name(name: str) -> str:
                 stack.pop()
             if len(stack) > 0 and stack[-1] == "(":
                 stack.pop()
-            print(stack)
         else:
             stack.append(c)
     return "".join(stack).split(" ")[-1]

--- a/hta/utils/utils.py
+++ b/hta/utils/utils.py
@@ -151,11 +151,14 @@ def shorten_name(name: str) -> str:
     This utility removes the functional arguments, template arguments, and return values
     to make the name easy to understand.
     """
-    if name.find("<") < 0:
+    if name.find("") < 0 and name.find("(") < 0:
+    if name.find("<") < 0 and name.find("(") < 0:
         return name
+
     s: str = name.replace("->", "")
     stack: List[str] = []
     for c in s:
+        print(c)
         if c == ">":  # match generic template arguments
             while len(stack) and stack[-1] != "<":
                 stack.pop()
@@ -167,6 +170,7 @@ def shorten_name(name: str) -> str:
                 stack.pop()
             if len(stack) > 0 and stack[-1] == "(":
                 stack.pop()
+            print(stack)
         else:
             stack.append(c)
     return "".join(stack).split(" ")[-1]

--- a/hta/utils/utils.py
+++ b/hta/utils/utils.py
@@ -151,6 +151,8 @@ def shorten_name(name: str) -> str:
     This utility removes the functional arguments, template arguments, and return values
     to make the name easy to understand.
     """
+    if name.find("<") < 0:
+        return name
     s: str = name.replace("->", "")
     stack: List[str] = []
     for c in s:

--- a/tests/test_trace_analysis.py
+++ b/tests/test_trace_analysis.py
@@ -285,6 +285,12 @@ class TraceAnalysisTestCase(unittest.TestCase):
         self.assertEqual(kernel_breakdown.iloc[151]["kernel_type"], "MEMORY")
         self.assertEqual(kernel_breakdown.iloc[151]["sum (us)"], 1064)
 
+        # Negative test as this trace does not have gpu user annotations
+        gpu_kernels_df = (
+            self.vision_transformer_t.get_gpu_kernels_with_user_annotations(rank=0)
+        )
+        self.assertIsNone(gpu_kernels_df)
+
     def test_get_mtia_kernel_breakdown(self):
         (
             kernel_type_breakdown,

--- a/tests/test_trace_analysis.py
+++ b/tests/test_trace_analysis.py
@@ -6,6 +6,7 @@
 import os
 import unittest
 from collections import namedtuple
+from functools import cached_property
 from pathlib import Path
 from typing import List
 from unittest.mock import patch
@@ -16,10 +17,6 @@ from hta.trace_analysis import TimeSeriesTypes, TraceAnalysis
 
 
 class TraceAnalysisTestCase(unittest.TestCase):
-    vision_transformer_t: TraceAnalysis
-    inference_t: TraceAnalysis
-    df_index_resolver_t: TraceAnalysis
-    rank_non_gpu_t: TraceAnalysis
 
     @classmethod
     def setUpClass(cls):
@@ -38,19 +35,40 @@ class TraceAnalysisTestCase(unittest.TestCase):
             cls.base_data_dir, "rank_non_gpu/"
         )
         cls.h100_trace_dir: str = os.path.join(cls.base_data_dir, "h100")
-        cls.vision_transformer_t = TraceAnalysis(
-            trace_dir=cls.vision_transformer_trace_dir
-        )
-        cls.inference_t = TraceAnalysis(trace_dir=cls.inference_trace_dir)
-        cls.df_index_resolver_t = TraceAnalysis(
-            trace_dir=cls.df_index_resolver_trace_dir
-        )
-        cls.rank_non_gpu_t = TraceAnalysis(trace_dir=cls.rank_non_gpu_trace_dir)
-        cls.h100_trace_t = TraceAnalysis(trace_dir=cls.h100_trace_dir)
         cls.mtia_single_rank_dir: str = os.path.join(
             cls.base_data_dir, "mtia_trace_single_rank/"
         )
-        cls.mtia_single_rank_trace_t = TraceAnalysis(trace_dir=cls.mtia_single_rank_dir)
+        cls.ns_resolution_trace_dir: str = os.path.join(
+            cls.base_data_dir, "ns_resolution_trace"
+        )
+
+    @cached_property
+    def vision_transformer_t(self):
+        return TraceAnalysis(trace_dir=self.vision_transformer_trace_dir)
+
+    @cached_property
+    def inference_t(self):
+        return TraceAnalysis(trace_dir=self.inference_trace_dir)
+
+    @cached_property
+    def df_index_resolver_t(self):
+        return TraceAnalysis(trace_dir=self.df_index_resolver_trace_dir)
+
+    @cached_property
+    def rank_non_gpu_t(self):
+        return TraceAnalysis(trace_dir=self.rank_non_gpu_trace_dir)
+
+    @cached_property
+    def h100_trace_t(self):
+        return TraceAnalysis(trace_dir=self.h100_trace_dir)
+
+    @cached_property
+    def mtia_single_rank_trace_t(self):
+        return TraceAnalysis(trace_dir=self.mtia_single_rank_dir)
+
+    @cached_property
+    def ns_resolution_t(self):
+        return TraceAnalysis(trace_dir=self.ns_resolution_trace_dir)
 
     def setUp(self):
         self.overlaid_trace_dir = self.base_data_dir
@@ -281,6 +299,38 @@ class TraceAnalysisTestCase(unittest.TestCase):
         self.assertEqual(kernel_breakdown.iloc[0]["sum (us)"], 77283.0)
         self.assertEqual(kernel_breakdown.iloc[11]["kernel_type"], "MEMORY")
         self.assertEqual(kernel_breakdown.iloc[11]["sum (us)"], 400892.0)
+
+    def test_get_gpu_kernels_with_user_annotations(self):
+        gpu_kernels_df = self.ns_resolution_t.get_gpu_kernels_with_user_annotations(
+            rank=0,
+            expand_names=True,
+            shortern_names=True,
+        )
+        self.assertEqual(len(gpu_kernels_df), 4876)
+        # 3 unique annotations, +one for -1
+        self.assertEqual(gpu_kernels_df.user_annotation.unique().size, 4)
+
+        # Kernels with specific annotation
+        self.assertEqual(
+            len(
+                gpu_kernels_df[
+                    gpu_kernels_df.s_user_annotation == "Optimizer.step#SGD.step"
+                ]
+            ),
+            27,
+        )
+
+        row0 = gpu_kernels_df[gpu_kernels_df.correlation == 135139]
+        self.assertEqual(
+            row0["s_user_annotation"].item(), "DistributedDataParallel.forward"
+        )
+        self.assertEqual(row0["s_name"].item(), "Memcpy DtoD (Device -> Device)")
+
+        row1 = gpu_kernels_df[gpu_kernels_df.correlation == 164926]
+        self.assertEqual(row1["s_user_annotation"].item(), "Optimizer.step#SGD.step")
+        self.assertEqual(
+            row1["s_name"].item(), "at::native::::multi_tensor_apply_kernel"
+        )
 
     def test_get_queue_length_stats(self):
         qd_summary = self.vision_transformer_t.get_queue_length_summary(ranks=[0])

--- a/tests/test_trace_utils.py
+++ b/tests/test_trace_utils.py
@@ -21,6 +21,7 @@ class TestTracUtils(unittest.TestCase):
                 "void at::native::vectorized_elementwise_kernel<4, at::native::CUDAFunctor_add<int>, at::detail::Array<char*, 3> >(int, at::native::CUDAFunctor_add<int>, at::detail::Array<char*, 3>)",
                 "at::native::vectorized_elementwise_kernel",
             ),
+            TC("Memcpy DtoD (Device -> Device)", "Memcpy DtoD (Device -> Device)"),
         ]
 
         for tc in test_cases:


### PR DESCRIPTION
## What does this PR do?
Adds a trace analysis method to get GPU kernel breakdown by user annotation range.
Addresses #206 #180 

## Example notebook

[
![Screenshot 2025-01-30 at 6 20 53 PM](https://github.com/user-attachments/assets/b30310f2-ce80-4ce3-ac1c-ad789b6ada65)
![Screenshot 2025-01-30 at 6 20 46 PM](https://github.com/user-attachments/assets/03716fb8-fa7a-4b20-8d8d-d63331c80bdb)
](url)

## Tests
Testplan:

```
pytest tests/test_trace_analysis.py -k test_get_gpu_kernels_with_user_annotations
pytest tests/test_trace_utils.py -k test_shorten_name
```

## Before submitting

- [y] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [y] Did you write any new necessary tests?
  - [ ] N/A
- [y] Did you make sure to update the docs?
  - [ ] N/A
- [y] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [ ] N/A
