### PR TITLE
Add batch size and batch Id in trace format

### DIFF
--- a/hta/configs/event_args_formats/event_args_1.0.0.yaml
+++ b/hta/configs/event_args_formats/event_args_1.0.0.yaml
@@ -234,3 +234,13 @@ AVAILABLE_ARGS:
     raw_name: Rank
     value_type: Int
     default_value: -1
+  inference::batch_size:
+    name: batch_size
+    raw_name: batchSize
+    value_type: Int
+    default_value: -1
+  inference::batch_id:
+    name: batch_id
+    raw_name: batchId
+    value_type: String
+    default_value: ""


### PR DESCRIPTION
Summary:
**Context**
Added batch size and batch id annotation to inference trace in D63801503. This info will be useful to unblock future inference batch size analysis 

**This diff**
Changes trace event args format to include these 2 new args in trace

Differential Revision: D68803499


