### PR TITLE
Add finished arg parsing from kineto trace

### DIFF
--- a/hta/configs/event_args_formats/event_args_1.0.0.yaml
+++ b/hta/configs/event_args_formats/event_args_1.0.0.yaml
@@ -137,6 +137,11 @@ AVAILABLE_ARGS:
     raw_name: wait_on_cuda_event_record_corr_id
     value_type: Int
     default_value: -1
+  info::finished:
+    name: finished
+    raw_name: finished
+    value_type: String
+    default_value: ""
   info::labels:
     name: labels
     raw_name: labels


### PR DESCRIPTION
Summary: Noticed that we get a separate arg that indicates if the trace event has finished. Adding this in trace format as this field may become useful for inference trace analysis

Reviewed By: sraikund16

Differential Revision: D69544251


