### PR TITLE
GPU user annotations implement allowlist feature

### DIFF
--- a/hta/analyzers/breakdown_analysis.py
+++ b/hta/analyzers/breakdown_analysis.py
@@ -350,6 +350,7 @@ class BreakdownAnalysis:
         visualize: bool = True,
         duration_ratio: float = 0.8,
         num_kernels: int = 1000,
+        allowlist_patterns: Optional[List[str]] = None,
         image_renderer: Optional[str] = None,
     ) -> Optional[pd.DataFrame]:
         """
@@ -364,6 +365,7 @@ class BreakdownAnalysis:
             duration_ratio (float): Floating point value between 0 and 1 specifying the ratio of time taken
                                     by top user annotations. Default = 0.8.
             num_kernels (int): Maximum number of user annotations to show. Default = 1000. Rest get grouped into "other".
+            allowlist_patterns (list(str): if user annotations match any of the patterns in this list, they will not be aggregated into "other" catgory. This argument is meant to keep some kernel/events as distinct in the aggregation
             image_renderer (str): Set to ``notebook`` when using jupyter and ``jupyterlab`` when using jupyter-lab.
                 To see all available options execute: ``import plotly; plotly.io.renderers`` in a python shell.
 
@@ -393,6 +395,9 @@ class BreakdownAnalysis:
                 "rank": pd.Series(dtype="int"),
             }
         )
+        allowlist_names: Optional[List[str]] = None
+        if allowlist_patterns is not None:
+            allowlist_names = t.symbol_table.find_matched_symbols(allowlist_patterns)
 
         kernel_per_rank: Dict[int, pd.DataFrame] = {}
 
@@ -407,6 +412,7 @@ class BreakdownAnalysis:
                 gpu_user_annotation_kernels,
                 duration_ratio=duration_ratio,
                 num_kernels=num_kernels,
+                allowlist_names=allowlist_names,
             )
             gpu_kernel_time["rank"] = int(rank)
             kernel_per_rank[rank] = gpu_kernel_time
@@ -558,9 +564,27 @@ class BreakdownAnalysis:
     def _aggr_gpu_kernel_time(
         cls,
         gpu_kernel_time: pd.DataFrame,
-        duration_ratio: float = 0.8,
         num_kernels: int = 10,
+        duration_ratio: float = 0.8,
+        allowlist_names: Optional[List[str]] = None,
     ) -> pd.DataFrame:
+        """
+        Aggregates GPU kernel/events
+
+            @args: gpu_kernel_time: flat dataframe of events to consider
+            @args: num_kernels (int) : Max number of kernels to show in result. If the
+                aggregate exceeds this the rest of the kernels are grouped into "other",
+                by first sorting by duration in descending order.
+            @args: duration_ratio (float) : a quantile threshold above which kernels are grouped
+                into "other" category. For example, setting to 0.8 will result is all kernels
+                past > p80 to be grouped together.
+            @args: allowlist_names (list(str): if kernel names are in this list, they will not be aggregated into "other" catgory.
+                This argument is meant to keep some kernel/events as distinct in the aggregation
+
+        Returns:
+            aggregated pd.DataFrame by "name" column with ["sum", "max", "min", "mean", "std"]
+        """
+
         gpu_kernel_time = gpu_kernel_time.groupby(by=["name"])["dur"].agg(
             ["sum", "max", "min", "mean", "std"]
         )
@@ -572,15 +596,23 @@ class BreakdownAnalysis:
 
         # if there are more than num_kernels kernels, starting to aggregate kernels
         if gpu_kernel_time.shape[0] > num_kernels:
+            if allowlist_names is not None:
+                keep_idx = gpu_kernel_time.name.isin(allowlist_names)
+            else:
+                # always false
+                keep_idx = gpu_kernel_time["sum"] < 0
+
             gpu_kernel_time["cumsum"] = gpu_kernel_time["sum"].cumsum()
             quantiles = gpu_kernel_time["cumsum"].quantile(duration_ratio)
             # FIXME linter mismatch between fbcode and git T183519933
             # fmt: off
-            gpu_kernel_time.loc[gpu_kernel_time["cumsum"] > quantiles, "name"] = (
+            gpu_kernel_time.loc[~keep_idx & (gpu_kernel_time["cumsum"] > quantiles), "name"] = (
                 "others"
             )
             # fmt: on
-            gpu_kernel_time.loc[gpu_kernel_time.index >= num_kernels, "name"] = "others"
+            gpu_kernel_time.loc[
+                ~keep_idx & (gpu_kernel_time.index >= num_kernels), "name"
+            ] = "others"
             gpu_kernel_time = gpu_kernel_time.groupby(by=["name"])["sum"].agg(
                 ["sum", "max", "min", "mean", "std"]
             )

--- a/hta/analyzers/breakdown_analysis.py
+++ b/hta/analyzers/breakdown_analysis.py
@@ -365,7 +365,7 @@ class BreakdownAnalysis:
             duration_ratio (float): Floating point value between 0 and 1 specifying the ratio of time taken
                                     by top user annotations. Default = 0.8.
             num_kernels (int): Maximum number of user annotations to show. Default = 1000. Rest get grouped into "other".
-            allowlist_patterns (list(str): if user annotations match any of the patterns in this list, they will not be aggregated into "other" catgory. This argument is meant to keep some kernel/events as distinct in the aggregation
+            allowlist_patterns (list(str)): if user annotations match any of the patterns in this list, they will not be aggregated into "other" catgory. This argument is meant to keep some events as distinct in the aggregation. Supports strings as well as regular expressions.
             image_renderer (str): Set to ``notebook`` when using jupyter and ``jupyterlab`` when using jupyter-lab.
                 To see all available options execute: ``import plotly; plotly.io.renderers`` in a python shell.
 

--- a/hta/common/trace_symbol_table.py
+++ b/hta/common/trace_symbol_table.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import multiprocessing as mp
 
 import queue
+import re
 from typing import Any, Dict, Iterable, List
 
 import pandas as pd
@@ -78,6 +79,38 @@ class TraceSymbolTable:
 
     def get_sym_table(self) -> List[str]:
         return self.sym_table
+
+    def find_matches(self, patterns: List[str]) -> List[int]:
+        """
+        Get the indices in sym_table where any of the given patterns match.
+
+        Args:
+            patterns (List[str]): The list of patterns to match, can be regular expressions.
+
+        Returns:
+            List[int]: A list of indices where a pattern matches.
+        """
+        # Compile the patterns into a single regex pattern
+        pattern = re.compile("|".join(re.escape(p) for p in patterns))
+
+        # Find the indices of matches
+        return [i for i, s in enumerate(self.sym_table) if pattern.search(s)]
+
+    def find_matched_symbols(self, patterns: List[str]) -> List[str]:
+        """
+        Get symbols where any of the given patterns match.
+
+        Args:
+            patterns (List[str]): The list of patterns to match, can be regular expressions.
+
+        Returns:
+            List[str]: A list of symbols where the pattern matches
+        """
+        # Compile the patterns into a single regex pattern
+        pattern = re.compile("|".join(re.escape(p) for p in patterns))
+
+        # Find the indices of matches
+        return [s for s in self.sym_table if pattern.search(s)]
 
     def add_symbols_to_trace_df(self, trace_df: pd.DataFrame, col: str) -> None:
         """

--- a/hta/common/trace_symbol_table.py
+++ b/hta/common/trace_symbol_table.py
@@ -109,7 +109,7 @@ class TraceSymbolTable:
         # Compile the patterns into a single regex pattern
         pattern = re.compile("|".join(re.escape(p) for p in patterns))
 
-        # Find the indices of matches
+        # Find the names of matches
         return [s for s in self.sym_table if pattern.search(s)]
 
     def add_symbols_to_trace_df(self, trace_df: pd.DataFrame, col: str) -> None:

--- a/hta/trace_analysis.py
+++ b/hta/trace_analysis.py
@@ -206,6 +206,7 @@ class TraceAnalysis:
             duration_ratio (float): Floating point value between 0 and 1 specifying the ratio of time taken
                                     by top user annotations. Default = 0.8.
             num_kernels (int): Maximum number of user annotations to show. Default = 1000. Rest get grouped into "other".
+            allowlist_patterns (list(str)): if user annotations match any of the patterns in this list, they will not be aggregated into "other" catgory. This argument is meant to keep some events as distinct in the aggregation. Supports strings as well as regular expressions.
             image_renderer (str): Set to ``notebook`` when using jupyter and ``jupyterlab`` when using jupyter-lab.
                 To see all available options execute: ``import plotly; plotly.io.renderers`` in a python shell.
 

--- a/hta/trace_analysis.py
+++ b/hta/trace_analysis.py
@@ -191,6 +191,7 @@ class TraceAnalysis:
         visualize: bool = True,
         duration_ratio: float = 0.8,
         num_kernels: int = 1000,
+        allowlist_patterns: Optional[List[str]] = None,
         image_renderer: Optional[str] = None,
     ) -> Optional[pd.DataFrame]:
         r"""
@@ -223,6 +224,7 @@ class TraceAnalysis:
             visualize,
             duration_ratio,
             num_kernels,
+            allowlist_patterns,
             image_renderer,
         )
 

--- a/tests/test_symbol_table.py
+++ b/tests/test_symbol_table.py
@@ -70,6 +70,17 @@ class TraceSymbolTableTestCase(unittest.TestCase):
         ]
         self.assertTrue(all(is_consistent))
 
+    def test_symbol_pattern_match(self):
+        st = TraceSymbolTable()
+        st.add_symbols_mp(self.symbols_list)
+        patterns = ["b"]
+
+        expected_symbols = {"b", "b3", "b2", "b1"}
+        self.assertEqual(expected_symbols, set(st.find_matched_symbols(patterns)))
+
+        expected_idxs = {st.sym_index[s] for s in expected_symbols}
+        self.assertEqual(expected_idxs, set(st.find_matches(patterns)))
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()

--- a/tests/test_trace_analysis.py
+++ b/tests/test_trace_analysis.py
@@ -346,6 +346,21 @@ class TraceAnalysisTestCase(unittest.TestCase):
             use_gpu_annotation=False, expected_rows=12
         )
 
+    def test_cpu_user_annotation_breakdown_with_allowlist(self):
+        """Test the allowlist mode"""
+        analyzer = self.ns_resolution_t
+        allowlist_patterns = ["Optimizer"]
+
+        cpu_user_anno_df = analyzer.get_gpu_user_annotation_breakdown(
+            visualize=False,
+            num_kernels=5,
+            use_gpu_annotation=False,
+            allowlist_patterns=allowlist_patterns,
+        )
+        # Expect 8 rows, 5 original + 2 for Optimizer + 1 others
+        self.assertEqual(len(cpu_user_anno_df), 8)
+        self.assertEqual(int(cpu_user_anno_df.name.str.contains("Optimizer").sum()), 2)
+
     def test_get_gpu_kernels_with_user_annotations(self):
         gpu_kernels_df = self.ns_resolution_t.get_gpu_kernels_with_user_annotations(
             rank=0,


### PR DESCRIPTION
## What does this PR do?
We would like to avoid clubbing certain CPU/GPU user annotations into the "other" category as they may have special signficance in our analysis.
Adds an allowlist that retains user annotations matching certain patterns.

## Testing

<img width="879" alt="Screenshot 2025-02-21 at 12 14 28 PM" src="https://github.com/user-attachments/assets/c28d60a9-dc67-4800-af14-38cdfeffb07c" />


## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [x] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [ ] N/A
