### PR TITLE
229 parse all arguments in pytorch trace file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Queue length analysis: Add feature to compute time blocked on a stream hitting max queue length.
 - Add `kernel_backend` to parser config for Triton / torch.compile() support.
 - Add analyses features for GPU user annotation attribution at trace and kernel level.
+- Add support to parse all trace event args.
 
 #### Changed
 - Change test data path in unittests from relative path to real path to support running test within IDEs.

--- a/hta/common/trace_parser.py
+++ b/hta/common/trace_parser.py
@@ -181,6 +181,9 @@ def _parse_trace_events_ijson_batched(
                 e[arg_name_map[arg]] = val
             elif e.get("cat", "") == "cuda_profiler_range":
                 e[arg] = val
+            elif cfg.parse_all_args:
+                e[cfg.transform_arg_name(arg)] = val
+
         e.pop("args", None)
         return e
 
@@ -278,6 +281,12 @@ def _compress_df(
         )
         logger.info(f"counter_names={counter_names}")
         logger.info(f"args={cfg.get_args()}")
+
+    if "args" in columns and cfg.parse_all_args:
+        cfg = cfg.clone()
+        arg_map = cfg.infer_attribute_specs(df["args"], cfg.get_all_available_args())
+        cfg.set_args(list(arg_map.values()))
+        logger.info("Inferred and set attribute specs from the values of args column")
 
     if "args" in columns:
         args_to_keep = cfg.get_args()

--- a/hta/configs/config.py
+++ b/hta/configs/config.py
@@ -140,7 +140,7 @@ class HtaConfig:
     def show(self):
         print(json.dumps(self.config, indent=4, sort_keys=True))
 
-    @classmethod
-    def get_test_data_path(cls, dataset: str) -> str:
-        test_data_path = Path.joinpath(package_path, "tests/data/", dataset)
+    @staticmethod
+    def get_test_data_path(dataset: str) -> str:
+        test_data_path = package_path.parent.joinpath("tests/data/", dataset)
         return str(test_data_path)

--- a/hta/configs/default_values.py
+++ b/hta/configs/default_values.py
@@ -63,6 +63,16 @@ class AttributeSpec(NamedTuple):
     # not break backwards compatibility with other fields (minor version bumps).
     min_supported_version: YamlVersion
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, AttributeSpec):
+            return False
+        return (
+            self.name == other.name
+            and self.raw_name == other.raw_name
+            and self.value_type == other.value_type
+            and self.default_value == other.default_value
+        )
+
 
 class EventArgs(NamedTuple):
     AVAILABLE_ARGS: Dict[str, AttributeSpec]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,7 @@
 
 import json
 import unittest
+from pathlib import Path
 
 from hta.configs.config import HtaConfig
 from hta.configs.default_values import DEFAULT_CONFIG_FILENAME
@@ -72,6 +73,10 @@ class HtaConfigTestCase(unittest.TestCase):
 
     def test_get_env_options(self):
         self.assertNotEqual(get_options(), "")
+
+    def test_get_test_data_path(self):
+        data_path = HtaConfig.get_test_data_path("h100")
+        self.assertTrue(Path(data_path).exists())
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_parser_config.py
+++ b/tests/test_parser_config.py
@@ -1,7 +1,20 @@
 import unittest
-from typing import List, NamedTuple, Optional
+from typing import Dict, List, NamedTuple, Optional
 
-from hta.configs.parser_config import AttributeSpec, AVAILABLE_ARGS, ParserConfig
+import pandas as pd
+
+from hta.configs.default_values import ValueType, YamlVersion
+from hta.configs.event_args_yaml_parser import parse_event_args_yaml
+from hta.configs.parser_config import (
+    AttributeSpec,
+    AVAILABLE_ARGS,
+    DEFAULT_PARSE_VERSION,
+    ParserBackend,
+    ParserConfig,
+)
+from hta.utils.test_utils import data_provider
+
+_MODULE_NAME = "hta.configs.parser_config"
 
 
 class ParserConfigTestCase(unittest.TestCase):
@@ -59,3 +72,183 @@ class ParserConfigTestCase(unittest.TestCase):
                 ParserConfig.get_default_cfg().get_args(), custom_cfg.get_args()
             )
         )
+
+    @data_provider(
+        lambda: [
+            {
+                "arg_name": "Kernel Queued",
+                "expected_transformed": "kernel_queued",
+            },
+            {
+                "arg_name": "Cuda-Kernel/Queued",
+                "expected_transformed": "cuda_kernel_queued",
+            },
+            {
+                "arg_name": "Kernel.a(.Queued)__b_%",
+                "expected_transformed": "kernel_a_b",
+            },
+            {
+                "arg_name": "name",
+                "expected_transformed": "arg_name",
+            },
+        ]
+    )
+    def test_transform_arg_name(self, arg_name: str, expected_transformed: str) -> None:
+        self.assertEqual(
+            ParserConfig.transform_arg_name(arg_name), expected_transformed
+        )
+
+    @data_provider(
+        lambda: [
+            {
+                "cfg": ParserConfig(args=ParserConfig.get_minimum_args()),
+                "args_selector": None,
+                "expected_args": ParserConfig.get_minimum_args(),
+            },
+            {
+                "cfg": ParserConfig(args=ParserConfig.get_minimum_args()),
+                "args_selector": ["stream"],
+                "expected_args": [
+                    AttributeSpec(
+                        "stream", "stream", ValueType.Int, -1, DEFAULT_PARSE_VERSION
+                    )
+                ],
+            },
+        ]
+    )
+    def test_args_selector(
+        self,
+        cfg: ParserConfig,
+        args_selector: Optional[List[str]],
+        expected_args: List[str],
+    ) -> None:
+        cfg.set_args_selector(args_selector)
+        self.assertListEqual(cfg.get_args(), expected_args)
+
+    def test_set_parse_all_args(self) -> None:
+        cfg = ParserConfig()
+        # Test default value is False
+        cfg.set_parse_all_args(False)
+
+        # Test setting to True
+        cfg.set_parse_all_args(True)
+        self.assertTrue(cfg.parse_all_args)
+
+        # Test setting to False
+        cfg.set_parse_all_args(False)
+        self.assertFalse(cfg.parse_all_args)
+
+    def test_set_global_parser_config_version(self) -> None:
+        cfg = ParserConfig()
+        version = YamlVersion(1, 0, 0)
+        cfg.set_global_parser_config_version(version)
+        self.assertEqual(cfg.version.get_version_str(), "1.0.0")
+        self.assertEqual(
+            ParserConfig.get_default_cfg().version.get_version_str(), "1.0.0"
+        )
+
+    def test_set_min_required_cols(self) -> None:
+        cfg = ParserConfig()
+        cols = ["a", "b", "c"]
+        cfg.set_min_required_cols(cols)
+        self.assertSetEqual(set(cfg.get_min_required_cols()), set(cols))
+
+    def test_set_trace_memory(self) -> None:
+        cfg = ParserConfig()
+        self.assertFalse(cfg.trace_memory)
+        cfg.set_trace_memory(True)
+        self.assertTrue(cfg.trace_memory)
+        cfg.set_trace_memory(False)
+        self.assertFalse(cfg.trace_memory)
+
+    def test_set_parser_backend(self) -> None:
+        cfg = ParserConfig()
+        for backend in ParserBackend:
+            cfg.set_parser_backend(backend)
+            self.assertEqual(cfg.parser_backend, backend)
+
+    @data_provider(
+        lambda: [
+            {
+                "arg_name": "arg1",
+                "arg_value": 1,
+                "arg_spec": AttributeSpec(
+                    "arg1", "arg1", ValueType.Int, 0, DEFAULT_PARSE_VERSION
+                ),
+            },
+            {
+                "arg_name": "arg2",
+                "arg_value": 1.0,
+                "arg_spec": AttributeSpec(
+                    "arg2", "arg2", ValueType.Float, 0.0, DEFAULT_PARSE_VERSION
+                ),
+            },
+            {
+                "arg_name": "arg3",
+                "arg_value": "1",
+                "arg_spec": AttributeSpec(
+                    "arg3", "arg3", ValueType.String, "", DEFAULT_PARSE_VERSION
+                ),
+            },
+            {
+                "arg_name": "arg4",
+                "arg_value": {},
+                "arg_spec": AttributeSpec(
+                    "arg4", "arg4", ValueType.Object, None, DEFAULT_PARSE_VERSION
+                ),
+            },
+        ]
+    )
+    def test_make_attribute_spec(
+        self, arg_name: str, arg_value: object, arg_spec: AttributeSpec
+    ) -> None:
+        result_spec = ParserConfig.make_attribute_spec(arg_name, arg_value)
+        self.assertEqual(result_spec, arg_spec)
+
+    def test_infer_attribute_specs(self) -> None:
+        cfg = ParserConfig()
+        args = pd.Series(
+            [
+                {"arg1": 1, "arg2": 1.0},
+                {"arg1": 2, "arg2": 2.0, "arg3": "abc"},
+                {"arg4": {"key": "value"}},
+                {"arg5": 3, "arg6": 3.0},
+                None,
+            ]
+        )
+        reference_specs: Dict[str, AttributeSpec] = {
+            "ref::arg5": AttributeSpec(
+                "arg5_ref", "arg5", ValueType.Int, 0, DEFAULT_PARSE_VERSION
+            ),
+            "ref::arg6": AttributeSpec(
+                "arg6_ref", "arg6", ValueType.Float, 10.0, DEFAULT_PARSE_VERSION
+            ),
+        }
+        expected_result = {
+            "arg1": AttributeSpec(
+                "arg1", "arg1", ValueType.Int, 0, DEFAULT_PARSE_VERSION
+            ),
+            "arg2": AttributeSpec(
+                "arg2", "arg2", ValueType.Float, 0.0, DEFAULT_PARSE_VERSION
+            ),
+            "arg3": AttributeSpec(
+                "arg3", "arg3", ValueType.String, "", DEFAULT_PARSE_VERSION
+            ),
+            "arg4": AttributeSpec(
+                "arg4", "arg4", ValueType.Object, None, DEFAULT_PARSE_VERSION
+            ),
+            "arg5": reference_specs["ref::arg5"],
+            "arg6": reference_specs["ref::arg6"],
+        }
+        result = cfg.infer_attribute_specs(args, reference_specs=reference_specs)
+        self.assertDictEqual(result, expected_result)
+
+    def test_enable_communication_args(self) -> None:
+        cfg = ParserConfig.get_versioned_cfg(DEFAULT_PARSE_VERSION)
+        cfg_1 = ParserConfig.enable_communication_args(cfg)
+        for arg in parse_event_args_yaml(DEFAULT_PARSE_VERSION).ARGS_COMMUNICATION:
+            self.assertIn(arg, cfg_1.get_args())
+
+        # Run the following two steps purely for test coverage
+        ParserConfig.show_available_args()
+        ParserConfig.get_info_args()


### PR DESCRIPTION
## What does this PR do?

- The HTA currently filters a specific set of arguments defined by the ParserConfig class. This approach effectively minimizes memory footprint, which is crucial when dealing with fixed traces.

- When working with new types of traces, such as MTIA traces, the current implementation requires modifying the ParserConfig class. This introduces an additional layer of effort and potential complexity.

### Proposed Solution
We're adding a new boolean attribute, `parse_all_arguments` (default `False`), to the `ParserConfig` class. When set to `True`, the parser will parse all arguments in the trace file. Arguments defined in `events_args` will be parsed as specified, while undefined arguments will be parsed using a standard naming convention with inferred default values.

The undefined arguments are parsed with the following method:
name: the converted name, which is the raw name from the trace file converted to lowercase and with spaces replaced by underscores.

- raw_name: the original name as it appeared in the trace file
- value_type, the data type inferred based on the value that was given to the argument 
- default_value: -1 for int, "" for string, None for object

Benefits

- Flexibility: Enables seamless adaptation to new trace types without modifying the ParserConfig class.
- Ease of Use: Provides a simple and intuitive way to toggle between parsing specific arguments and parsing all arguments.
- Reduced Maintenance: Simplifies the codebase by eliminating the need for frequent updates to the ParserConfig class for new trace types.

## Before submitting

- [X] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [X] Did you write any new necessary tests?
  - [ ] N/A
- [X] Did you make sure to update the docs?
  - [ ] N/A
- [X] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [ ] N/A
