### PR TITLE
Fix trace start time unit test

### DIFF
--- a/tests/test_trace_parse.py
+++ b/tests/test_trace_parse.py
@@ -131,6 +131,7 @@ class TraceParseTestCase(unittest.TestCase):
         # Trace parser for triton
         cls.triton_t: Trace = Trace(trace_dir=triton_trace_dir)
         cls.triton_t.parse_traces(max_ranks=max_ranks, use_multiprocessing=True)
+        cls.triton_t.align_and_filter_trace()
         cls.triton_raw_df = prepare_ground_truth_df(
             triton_trace_dir, triton_example_file
         )


### PR DESCRIPTION
## What does this PR do?
The test missed aligning trace which will basically set the self.min_ts arg in trace

## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [x] N/A
