### PR TITLE
: Filter out GPU events with no correlation

### DIFF
--- a/hta/common/trace_filter.py
+++ b/hta/common/trace_filter.py
@@ -327,7 +327,9 @@ def _filter_gpu_kernels_with_cuda_sync(
     # run on GPU
     event_sync_id = symbol_table.get_sym_id_map().get("Event Sync", -1)
     context_sync_id = symbol_table.get_sym_id_map().get("Context Sync", -1)
-    return (df["stream"] >= 0) | df["name"].isin([event_sync_id, context_sync_id])
+    return ((df["stream"] >= 0) & (df["correlation"] >= 0)) | df["name"].isin(
+        [event_sync_id, context_sync_id]
+    )
 
 
 class GPUKernelFilter(Filter):
@@ -346,7 +348,7 @@ class GPUKernelFilter(Filter):
             logger.warning(
                 "GPUKernelFilter needs symbol table to identify GPU synchronization events"
             )
-            return df.loc[df["stream"] >= 0]
+            return df.loc[(df["stream"] >= 0) & (df["correlation"] >= 0)]
 
         return df.loc[_filter_gpu_kernels_with_cuda_sync(df, symbol_table)]
 


### PR DESCRIPTION
Summary:
The inner merge seems to be creating all possible combinations of correlation (-1, -1) from both cpu and gpu data frames and OOM'ing.

This diff fixes the issue by filtering out GPU events with index correlation < 0

Note: This wasnt an issue before because this seems to happen (on nvidia traces) only when stream == 0. The change made to enable AMD caused this corner case to trigger.

Differential Revision: D72218256


