### PR TITLE
add internal functionality to trace symbol table.

### DIFF
--- a/hta/common/trace_call_graph.py
+++ b/hta/common/trace_call_graph.py
@@ -117,9 +117,7 @@ class CallGraph:
         """
         t = Trace(trace_files={}, trace_dir="")
         t.symbol_table = (
-            symbol_table
-            if symbol_table
-            else TraceSymbolTable.create_symbol_table_from_df(df)
+            symbol_table if symbol_table else TraceSymbolTable.create_from_df(df)
         )
         t.traces[rank] = df.copy()
         t.is_parsed = True

--- a/hta/common/trace_symbol_table.py
+++ b/hta/common/trace_symbol_table.py
@@ -2,16 +2,25 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+
 from __future__ import annotations
 
 import multiprocessing as mp
-
+import os
 import queue
 import re
-from typing import Any, Dict, Iterable, List
+from typing import Dict, Iterable, List
 
 import pandas as pd
+from hta.common.types import (
+    CPU_EVENTS_CATEGORY_PATTERN,
+    GroupingPattern,
+    KERNEL_CATEGORY_PATTERN,
+    MemoryKernelGroupingPattern,
+    ProfilerStepGroupingPattern,
+)
 
+from hta.configs.default_values import MAX_NUM_PROCESSES_SMALL
 from hta.utils.utils import shorten_name
 
 
@@ -22,7 +31,7 @@ class _SymbolCollector:
     implements a function object so that it allow the multiple processes to share the data.
     """
 
-    def __init__(self, q: queue.Queue[Any]):
+    def __init__(self, q: queue.Queue[str]) -> None:
         self.queue = q
 
     def __call__(self, symbols: Iterable[str]) -> None:
@@ -36,7 +45,8 @@ class TraceSymbolTable:
     """
     TraceSymbolTable stores the bidirectional symbol<-->id mapping for all traces.
     Because of potential races caused by multiprocessing, we serialize updates to the
-    TraceSymbolTable using a synchronize.lock.
+    TraceSymbolTable using a synchronize.lock. The table maintains both dictionary and
+    pandas Series representations for efficient lookups and DataFrame operations.
 
     We assume all read operations to this table by a Trace object occur after it adds all its symbols.
     Therefore, there is no need to lock the read access.
@@ -44,13 +54,25 @@ class TraceSymbolTable:
     Attributes:
         sym_table (List[str]) : a list of symbols.
         sym_index (Dict[str, int]) : a map from symbol to ID.
+        sym_index_series (pd.series): A Series representation for the symbol table.
+        sym_table_series (pd.Series): A Series representation for the symbol index.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.sym_table: List[str] = []
         self.sym_index: Dict[str, int] = {}
+        self._sym_index_series: pd.Series = pd.Series(self.sym_index, dtype="int64")
+        self._sym_table_series: pd.Series = pd.Series(self.sym_table, dtype="string")
+
+    def is_empty(self) -> bool:
+        return len(self.sym_table) == 0
 
     def add_symbols(self, symbols: Iterable[str]) -> None:
+        """Add new symbols to the table.
+
+        Args:
+            symbols: Iterable of symbol strings to add
+        """
         for s in symbols:
             if s not in self.sym_index:
                 idx = len(self.sym_table)
@@ -58,12 +80,17 @@ class TraceSymbolTable:
                 self.sym_index[s] = idx
 
     def add_symbols_mp(self, symbols_list: List[Iterable[str]]) -> None:
+        """Add symbols using multiprocessing for parallel collection.
+
+        Args:
+            symbols_list: List of symbol iterables to process in parallel
+        """
         m = mp.Manager()
-        shared_queue: queue.Queue[Any] = m.Queue()
+        shared_queue: queue.Queue[str] = m.Queue()
         collector = _SymbolCollector(shared_queue)
 
-        with mp.get_context("spawn").Pool(
-            min(mp.cpu_count(), len(symbols_list))
+        with mp.get_context("fork").Pool(
+            min(MAX_NUM_PROCESSES_SMALL, mp.cpu_count(), len(symbols_list))
         ) as pool:
             pool.map(collector, symbols_list)
             pool.close()
@@ -75,9 +102,22 @@ class TraceSymbolTable:
         self.add_symbols(all_symbols)
 
     def get_sym_id_map(self) -> Dict[str, int]:
+        """Get the symbol to ID mapping dictionary.
+
+        Returns:
+            Dictionary mapping symbol strings to their integer IDs.
+        """
+        return self.sym_index
+
+    def get_sym_index(self) -> Dict[str, int]:
         return self.sym_index
 
     def get_sym_table(self) -> List[str]:
+        """Get the list of symbols.
+
+        Returns:
+            List of symbol strings in order of their IDs.
+        """
         return self.sym_table
 
     def find_matches(self, patterns: List[str]) -> List[int]:
@@ -112,6 +152,141 @@ class TraceSymbolTable:
         # Find the names of matches
         return [s for s in self.sym_table if pattern.search(s)]
 
+    def _update_symbol_series(self) -> None:
+        if len(self.sym_table) != len(self._sym_table_series):
+            self._sym_table_series = pd.Series(self.sym_table)
+            self._sym_index_series = pd.Series(self.sym_index)
+
+    def get_sym_index_series(self) -> pd.Series:
+        self._update_symbol_series()
+        return self._sym_index_series
+
+    def get_sym_table_series(self) -> pd.Series:
+        self._update_symbol_series()
+        return self._sym_table_series
+
+    def get_symbol_ids(self, symbol_pattern: GroupingPattern) -> Dict[str, int]:
+        """Get the category ids of events in a trace dataframe."""
+        s_map = self.get_sym_index_series()
+        mask = s_map.index.str.match(symbol_pattern.pattern)
+        if symbol_pattern.inverse_match:
+            mask = ~mask
+        return s_map[mask].to_dict()
+
+    def get_symbol_names(self, symbol_ids: List[int]) -> Dict[int, str]:
+        """Get the category ids of events in a trace dataframe."""
+        s_table = self.get_sym_table_series()
+        mask = s_table.index.isin(symbol_ids)
+        return s_table[mask].to_dict()
+
+    def _to_csv_file(self, file_path: str) -> None:
+        """Save the symbol table to a CSV file"""
+        pd.DataFrame(data=self.sym_table, columns=["symbol"]).to_csv(
+            file_path, index=True
+        )
+
+    @staticmethod
+    def from_csv_file(file_path: str) -> "TraceSymbolTable":
+        """Read a TraceSymbolTable from a CSV file. The CSV file should contain at least a `symbol` column.
+
+        Args:
+            file_path (str): path to a csv file that contains the symbol table.
+
+        Returns:
+            TraceSymbolTable: the constructed TraceSymbolTable.
+        """
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(f"File {file_path} does not exist.")
+
+        df = pd.read_csv(file_path)
+        if "symbol" not in df.columns:
+            raise ValueError(f"{file_path}: expect a column'symbol' in the csv")
+        symbol_table = TraceSymbolTable()
+        symbol_table.add_symbols(df["symbol"].tolist())
+        return symbol_table
+
+    @staticmethod
+    def combine_symbol_tables(tables: List["TraceSymbolTable"]) -> "TraceSymbolTable":
+        """Combine multiple symbol tables into one symbol table."""
+        result: TraceSymbolTable = TraceSymbolTable()
+        for t in tables:
+            result.add_symbols(t.get_sym_table())
+        return result
+
+    @staticmethod
+    def clone(symbol_table: "TraceSymbolTable") -> "TraceSymbolTable":
+        """Create a TraceSymbolTable by cloning <symbol_table>"""
+        tst: TraceSymbolTable = TraceSymbolTable()
+        tst.sym_table = symbol_table.sym_table.copy()
+        tst.sym_index = symbol_table.sym_index.copy()
+        return tst
+
+    @staticmethod
+    def create_from_df(df: pd.DataFrame) -> "TraceSymbolTable":
+        """Create a symbol table from a DataFrame's cat and name columns.
+
+        Creates a new symbol table containing all unique symbols found in the DataFrame's
+        'name' and 'cat' columns. The symbols are added in the order they appear.
+
+        Args:
+            df (pd.DataFrame): an input DataFrame which has columns `name` and `cat`.
+
+        Returns:
+            TraceSymbolTable: a symbol table containing all unique `name` and `cat` symbols in df.
+
+        Raise:
+            ValueError: when `df` doesn't have the `name` and `cat` columns or they are not string type.
+        """
+        if (
+            ("name" in df.columns)
+            and (df["name"].dtype.kind == "O")
+            and ("cat" in df.columns)
+            and (df["cat"].dtype == "O")
+        ):
+            symbols = set(df["cat"].unique()).union(set(df["name"].unique()))
+            symbol_table = TraceSymbolTable()
+            symbol_table.add_symbols(symbols)
+            return symbol_table
+        raise ValueError(
+            "Expect both name and cat columns of string types to be present in the dataframe"
+        )
+
+    @staticmethod
+    def create_from_symbol_id_map(symbol_id_map: Dict[str, int]) -> "TraceSymbolTable":
+        """Create a symbol table from the given symbol id map."""
+        max_id = max(symbol_id_map.values())
+        id_to_symbol_map = {v: k for (k, v) in symbol_id_map.items()}
+
+        tst = TraceSymbolTable()
+        tst.sym_table = [
+            id_to_symbol_map.get(i, f"Undefined-{i}") for i in range(max_id + 1)
+        ]
+        tst.sym_index.update({s: i for i, s in enumerate(tst.sym_table)})
+
+        return tst
+
+    def encode_df(self, df: pd.DataFrame) -> None:
+        """Encode the name and cat columns of a DataFrame with this symbol table."""
+        for col in ["name", "cat"]:
+            if col in df.columns and df[col].dtype.kind == "O":
+                df[col] = df[col].apply(lambda sym: self.sym_index[sym])
+
+    def decode_df(self, df: pd.DataFrame, create_new_columns: bool = True) -> None:
+        """Decode the name and cat columns of a DataFrame with this symbol table."""
+        for col in ["name", "cat"]:
+            if col in df.columns and df[col].dtype.kind == "i":
+                col_name = "s_" + col if create_new_columns else col
+                df[col_name] = df[col].apply(lambda idx: self.sym_table[idx])
+
+    def update_encoded_df(
+        self, df: pd.DataFrame, old_symbol_table: "TraceSymbolTable"
+    ) -> None:
+        """Update the cat and name columns of df that was encoded using old_symbol_table."""
+        new_map = self.get_sym_index()
+        old_table = old_symbol_table.get_sym_table()
+        for col in ["cat", "name"]:
+            df[col] = df[col].apply(lambda idx: new_map[old_table[idx]])
+
     def add_symbols_to_trace_df(self, trace_df: pd.DataFrame, col: str) -> None:
         """
         Take a trace dataframe and expand symbols in one of its columns.
@@ -124,35 +299,6 @@ class TraceSymbolTable:
         """
         trace_df[col] = trace_df[col].apply(
             lambda i: self.sym_table[i] if (0 <= i < len(self.sym_table)) else ""
-        )
-
-    @staticmethod
-    def create_symbol_table_from_df(df: pd.DataFrame) -> TraceSymbolTable:
-        """Create a symbol table from a DataFrame's cat and name columns.
-
-        Args:
-            df (pd.DataFrame): an input DataFrame.
-
-        Returns:
-            TraceSymbolTable: a symbol table containing all unique `name` and `cat` symbols in df.
-
-        Raise:
-            ValueError: when one of the follow two conditions happens:
-                (1) `df` doesn't have the `name` and `cat` columns; or
-                (2) they are not string type.
-        """
-        if (
-            ("name" in df.columns)
-            and (df.dtypes["name"] == "object")
-            and ("cat" in df.columns)
-            and (df.dtypes["cat"] == "object")
-        ):
-            symbols = set(df["cat"].unique()).union(set(df["name"].unique()))
-            symbol_table = TraceSymbolTable()
-            symbol_table.add_symbols(symbols)
-            return symbol_table
-        raise ValueError(
-            "Expect both name and cat columns of string types to be present in the dataframe"
         )
 
     # Use a number lower than -1 as a sentinel for missing symbols
@@ -192,6 +338,18 @@ class TraceSymbolTable:
             f"(name == {rocmMemcpyAsync_id}) or (name == {rocmMemsetAsync_id}) or "
             f"(name == {rocmMemcpyWithStream_id})) and (index_correlation > 0)"
         )
+
+    def get_cpu_event_cat_ids(self) -> List[int]:
+        return list(self.get_symbol_ids(CPU_EVENTS_CATEGORY_PATTERN).values())
+
+    def get_gpu_kernel_cat_ids(self) -> List[int]:
+        return list(self.get_symbol_ids(KERNEL_CATEGORY_PATTERN).values())
+
+    def get_profiler_step_ids(self) -> List[int]:
+        return list(self.get_symbol_ids(ProfilerStepGroupingPattern).values())
+
+    def get_memory_name_ids(self) -> List[int]:
+        return list(self.get_symbol_ids(MemoryKernelGroupingPattern).values())
 
 
 def decode_symbol_id_to_symbol_name(

--- a/hta/common/types.py
+++ b/hta/common/types.py
@@ -1,5 +1,7 @@
+import re
+from dataclasses import dataclass
 from enum import Enum
-from typing import Dict
+from typing import Dict, List, Optional, Union
 
 import pandas as pd
 
@@ -47,4 +49,146 @@ MEMCPY_TYPE_TO_STR: Dict[MemcpyType, str] = {
     MemcpyType.DTOH: "memcpy_dtoh",
     MemcpyType.HTOD: "memcpy_htod",
     MemcpyType.UNKNOWN: "memcpy_type_unknown",
+}
+
+# TODO Move these to a common constants file that can provide patterns and platform constants
+
+
+@dataclass
+class GroupingPattern:
+    pattern: re.Pattern[str]
+    inverse_match: bool = False
+    group_name: str = ""
+
+    def match(self, name: str) -> bool:
+        m = self.pattern.match(name) is not None
+        return m if not self.inverse_match else not m
+
+    def __hash__(self) -> int:
+        return hash((self.pattern.pattern, self.pattern.flags, self.inverse_match))
+
+
+def to_grouping_pattern(
+    pattern: Union[str, List[str], re.Pattern[str], GroupingPattern],
+    group_name: Optional[str] = None,
+    inverse_match: Optional[bool] = None,
+) -> GroupingPattern:
+    """Convert a pattern to a GroupingPattern object.
+
+    Args:
+        pattern: a pattern to be converted to a GroupingPattern object.
+            When pattern is a GroupingPattern object, it is returned as is and
+            the group_name and inverse_match are ignored.
+        group_name: a name of the pattern.
+        inverse_match: whether to invert the match result.
+    """
+    if isinstance(pattern, GroupingPattern):
+        return pattern
+    if isinstance(pattern, list):
+        pattern = "|".join("(" + pattern + ")" for pattern in pattern)
+
+    if isinstance(pattern, str):
+        pattern = re.compile(pattern)
+
+    if isinstance(pattern, re.Pattern):
+        pattern = GroupingPattern(
+            pattern,
+            inverse_match if inverse_match else False,
+            group_name if group_name else "",
+        )
+        return pattern
+    raise ValueError(f"Unsupported pattern type: {type(pattern)}")
+
+
+ProfilerStepGroupingPattern = GroupingPattern(
+    pattern=re.compile(r"^ProfilerStep#(\d+)"),
+    inverse_match=False,
+    group_name="Profiler Step",
+)
+
+MemoryKernelGroupingPattern = GroupingPattern(
+    pattern=re.compile(r"(^(hip)?Memcpy)|(^(hip)?Memset)|(^dma)"),
+    inverse_match=False,
+    group_name="Memory",
+)
+
+MTIAMemoryKernelGroupingPattern = GroupingPattern(
+    pattern=re.compile(r"(^dma)"),
+    inverse_match=False,
+    group_name="MTIA Memory",
+)
+
+CommunicateKernelGroupingPattern = GroupingPattern(
+    pattern=re.compile(r"(^nccl)"),
+    inverse_match=False,
+    group_name="Communicate",
+)
+
+ComputeKernelGroupingPattern = GroupingPattern(
+    pattern=re.compile(
+        r"(^nccl)|(.*Memcpy)|(.*Memset)|(.*dma)|(^.*Sync)|(cuda.*LaunchKernel)|(^runFunction)"
+    ),
+    inverse_match=True,
+    group_name="Compute",
+)
+
+KERNEL_CATEGORY_PATTERN = GroupingPattern(
+    re.compile("(kernel)|(gpu_mem.+)|(mtia_ccp_events)"), False, "GPU Kernels"
+)
+
+CPU_OP_CATEGORY_PATTERN: GroupingPattern = GroupingPattern(
+    re.compile("(cpu_op)|(user_annotation)"), False, "CPU Ops"
+)
+
+DEVICE_RUNTIME_CATEGORY_PATTERN = GroupingPattern(
+    re.compile("(cuda_runtime)|(mtia_runtime)"), False, "Device Runtimes"
+)
+
+MEMORY_CATEGORY_PATTERN = GroupingPattern(
+    re.compile("(gpu_mem.+)|(mtia_ccp_events)"), False, "Memory"
+)
+
+GPU_EVENT_CATEGORY_PATTERN: GroupingPattern = GroupingPattern(
+    group_name="GPU Events",
+    pattern=re.compile(r"(.*kernel)|(^gpu_mem)|(^mtia_ccp_events)|(^cuda_sync)"),
+    inverse_match=False,
+)
+
+CPU_EVENTS_CATEGORY_PATTERN: GroupingPattern = GroupingPattern(
+    group_name="CPU Events",
+    pattern=re.compile(r"(cpu_op)|(user_annotation)|(^(.+)_runtime)"),
+    inverse_match=False,
+)
+
+CPU_AND_GPU_EVENTS_CATEGORY_PATTERN: GroupingPattern = GroupingPattern(
+    group_name="CPU/GPU Events",
+    pattern=re.compile(
+        r"(cpu_op)|(user_annotation)|(cuda_runtime)"
+        + r"|(.*kernel)|(^gpu_mem)|(^mtia_ccp_events)|(^cuda_sync)"
+    ),
+    inverse_match=False,
+)
+
+PYTHON_FUNCTION_PATTERN: GroupingPattern = GroupingPattern(
+    group_name="Python Functions",
+    pattern=re.compile(r"(python_function)"),
+    inverse_match=False,
+)
+
+ALL_CATEGORY_PATTERN: GroupingPattern = GroupingPattern(
+    group_name="All",
+    pattern=re.compile(r".*"),
+    inverse_match=False,
+)
+
+CUDA_SYNC_PATTERN: GroupingPattern = GroupingPattern(
+    group_name="CUDA Sync",
+    pattern=re.compile(r"(cuda_sync)"),
+    inverse_match=False,
+)
+
+common_grouping_patterns: Dict[str, GroupingPattern] = {
+    "memory_kernels": MemoryKernelGroupingPattern,
+    "compute_kernels": ComputeKernelGroupingPattern,
+    "communicate_kernels": CommunicateKernelGroupingPattern,
 }

--- a/hta/configs/default_values.py
+++ b/hta/configs/default_values.py
@@ -15,6 +15,8 @@ DF_SYMBOL_COLUMNS: List[str] = ["cat", "name"]
 
 # Runtime configurations
 IS_DEBUG_ENABLED: bool = True
+# For non-compute-intensive tasks, do not use a large number of processes.
+MAX_NUM_PROCESSES_SMALL: int = 4
 MAX_NUM_PROCESSES: int = 32
 
 

--- a/tests/test_symbol_table.py
+++ b/tests/test_symbol_table.py
@@ -3,16 +3,23 @@
 # LICENSE file in the root directory of this source tree.
 
 import multiprocessing as mp
+import os
+import re
+import tempfile
 import unittest
-from typing import List, Set
+from typing import Dict, Iterable, List, Set
+
+import pandas as pd
 
 from hta.common.trace_symbol_table import TraceSymbolTable
+from hta.common.types import GroupingPattern
+from hta.utils.test_utils import data_provider
 
 
 class SymbolDecoder:
-    def __init__(self, symbol_table: TraceSymbolTable):
-        self.sym_table = symbol_table.get_sym_table()
-        self.sym_id_map = symbol_table.get_sym_id_map()
+    def __init__(self, symbol_table: TraceSymbolTable) -> None:
+        self.sym_table: List[str] = symbol_table.get_sym_table()
+        self.sym_id_map: Dict[str, int] = symbol_table.get_sym_id_map()
 
     def __call__(self, idx: int) -> str:
         return self.sym_table[idx]
@@ -31,12 +38,16 @@ class TraceSymbolTableTestCase(unittest.TestCase):
         self.symbols_2: List[str] = ["a", "b", "c", "b2", "d1"]
         self.symbols_3: List[str] = ["a", "b", "f", "b3", "d2"]
         ss: Set[str] = set()
-        self.symbols_list = [self.symbols_1, self.symbols_2, self.symbols_3]
+        self.symbols_list: List[Iterable[str]] = [
+            self.symbols_1,
+            self.symbols_2,
+            self.symbols_3,
+        ]
         for s in self.symbols_list:
             ss = ss.union(set(s))
-        self.symbols: List[str] = sorted(list(ss))
+        self.symbols: List[str] = sorted(ss)
 
-    def test_add_symbols_single_process(self):
+    def test_add_symbols_single_process(self) -> None:
         st = TraceSymbolTable()
         for symbols in [self.symbols_1, self.symbols_2, self.symbols_3]:
             st.add_symbols(symbols)
@@ -44,14 +55,14 @@ class TraceSymbolTableTestCase(unittest.TestCase):
         self.assertListEqual(sorted(st.get_sym_table()), self.symbols)
         self.assertTrue(check_symbol_table(st))
 
-    def test_add_symbols_multi_processing(self):
+    def test_add_symbols_multi_processing(self) -> None:
         st = TraceSymbolTable()
         st.add_symbols_mp(self.symbols_list)
 
         self.assertListEqual(sorted(st.get_sym_table()), self.symbols)
         self.assertTrue(check_symbol_table(st))
 
-    def test_query_symbols_multi_processes(self):
+    def test_query_symbols_multi_processes(self) -> None:
         st = TraceSymbolTable()
         st.add_symbols_mp(self.symbols_list)
         decoder = SymbolDecoder(st)
@@ -80,6 +91,169 @@ class TraceSymbolTableTestCase(unittest.TestCase):
 
         expected_idxs = {st.sym_index[s] for s in expected_symbols}
         self.assertEqual(expected_idxs, set(st.find_matches(patterns)))
+
+    def test_combine_symbol_tables(self) -> None:
+        t1: TraceSymbolTable = TraceSymbolTable()
+        t1.add_symbols(self.symbols_1)
+        t2: TraceSymbolTable = TraceSymbolTable()
+        t2.add_symbols(self.symbols_2)
+        t3: TraceSymbolTable = TraceSymbolTable()
+        t3.add_symbols(self.symbols_3)
+        t_combined = TraceSymbolTable.combine_symbol_tables([t1, t2, t3])
+        all_symbols = set(self.symbols_1)
+        all_symbols.update(self.symbols_2)
+        all_symbols.update(self.symbols_3)
+        self.assertSetEqual(all_symbols, set(t_combined.get_sym_id_map().keys()))
+
+    def test_clone_symbol_table(self) -> None:
+        t: TraceSymbolTable = TraceSymbolTable()
+        t.add_symbols(self.symbols_1)
+
+        t_cloned = TraceSymbolTable.clone(t)
+        # the two symbol table should be identical
+        self.assertListEqual(t.sym_table, t_cloned.sym_table)
+        self.assertDictEqual(t.sym_index, t_cloned.sym_index)
+
+        # changing one table should change the other.
+        t_cloned.add_symbols(["clone"])
+        self.assertIn("clone", t_cloned.sym_index)
+        self.assertNotIn("clone", t.sym_index)
+
+    def test_save_to_load_from_file(self) -> None:
+        t: TraceSymbolTable = TraceSymbolTable()
+        t.add_symbols(self.symbols_1)
+        with tempfile.TemporaryDirectory() as tmp_dirname:
+            symbol_table_file = os.path.join(tmp_dirname, "test_symbols.csv")
+            t._to_csv_file(symbol_table_file)
+            t_loaded = TraceSymbolTable.from_csv_file(symbol_table_file)
+            self.assertListEqual(t.sym_table, t_loaded.sym_table)
+            self.assertDictEqual(t.sym_index, t_loaded.sym_index)
+
+    def test_get_sym_table_series(self) -> None:
+        t: TraceSymbolTable = TraceSymbolTable()
+        t.add_symbols(self.symbols_1)
+        t.add_symbols(self.symbols_2)
+        self.assertListEqual(t.get_sym_table(), t.get_sym_table_series().to_list())
+        self.assertDictEqual(t.get_sym_index(), t.get_sym_index_series().to_dict())
+
+    def test_create_from_df(self) -> None:
+        df = pd.DataFrame(
+            data={
+                "name": ["a", "b", "a", "c"],
+                "cat": ["kernel", "cpu_op", "kernel", "user_annotation"],
+            }
+        )
+        t = TraceSymbolTable.create_from_df(df)
+        self.assertSetEqual(
+            set(t.get_sym_table_series().to_list()),
+            {"a", "b", "c", "kernel", "cpu_op", "user_annotation"},
+        )
+
+    def test_encode_decode_df(self) -> None:
+        df = pd.DataFrame(
+            data={
+                "name": ["a", "b", "a", "c"],
+                "cat": ["kernel", "cpu_op", "kernel", "user_annotation"],
+            }
+        )
+        st = TraceSymbolTable.create_from_df(df)
+
+        # encode the df
+        df_original = df.copy()
+        st.encode_df(df)
+
+        # decode the df
+        st.decode_df(df)
+        df_decoded = df.copy()
+
+        # Equality check
+        self.assertListEqual(
+            df_original["name"].to_list(), df_decoded["s_name"].to_list()
+        )
+        self.assertListEqual(
+            df_original["cat"].to_list(), df_decoded["s_cat"].to_list()
+        )
+
+    # pyre-ignore[56]
+    @data_provider(
+        lambda: (
+            {
+                "symbol_id_map": {"A": 1, "B": 2, "C": 4},
+                "expected_sym_table": ["Undefined-0", "A", "B", "Undefined-3", "C"],
+                "expected_sym_index": {
+                    "Undefined-0": 0,
+                    "A": 1,
+                    "B": 2,
+                    "Undefined-3": 3,
+                    "C": 4,
+                },
+            },
+        )
+    )
+    def test_create_from_symbol_id_map(
+        self,
+        symbol_id_map: Dict[str, int],
+        expected_sym_table: List[str],
+        expected_sym_index: Dict[str, int],
+    ) -> None:
+        tst = TraceSymbolTable.create_from_symbol_id_map(symbol_id_map)
+        self.assertListEqual(tst.sym_table, expected_sym_table)
+        self.assertDictEqual(tst.sym_index, expected_sym_index)
+
+    # pyre-ignore[56]
+    @data_provider(
+        lambda: (
+            {
+                "symbols": ["a", "b", "c", "b1"],
+                "symbol_pattern": GroupingPattern(
+                    group_name="test_1", pattern=re.compile(r"a|b"), inverse_match=False
+                ),
+                "expected_symbol_ids": {"a": 0, "b": 1, "b1": 3},
+            },
+            {
+                "symbols": ["a", "b", "c", "b1"],
+                "symbol_pattern": GroupingPattern(
+                    group_name="test_2", pattern=re.compile(r"a|b"), inverse_match=True
+                ),
+                "expected_symbol_ids": {"c": 2},
+            },
+        )
+    )
+    def test_get_symbol_ids(
+        self,
+        symbols: List[str],
+        symbol_pattern: GroupingPattern,
+        expected_symbol_ids: Dict[str, int],
+    ) -> None:
+        tst = TraceSymbolTable()
+        tst.add_symbols(symbols)
+
+        self.assertDictEqual(tst.get_symbol_ids(symbol_pattern), expected_symbol_ids)
+
+    # pyre-ignore[56]
+    @data_provider(
+        lambda: (
+            {
+                "symbols": ["a", "b", "c", "b1"],
+                "symbol_ids": [0, 1],
+                "expected_symbols": {0: "a", 1: "b"},
+            },
+            {
+                "symbols": ["a", "b", "c", "b1"],
+                "symbol_ids": [-1, 2, 5],
+                "expected_symbols": {2: "c"},
+            },
+        )
+    )
+    def test_get_symbol_names(
+        self,
+        symbols: List[str],
+        symbol_ids: List[int],
+        expected_symbols: Dict[int, str],
+    ) -> None:
+        tst = TraceSymbolTable()
+        tst.add_symbols(symbols)
+        self.assertDictEqual(tst.get_symbol_names(symbol_ids), expected_symbols)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
Summary:
This diff adds internal functionality to the trace symbol table in the Holistic Trace Analysis (HTA) library based on an internal fork of the code. Thanks to fengxizhou for the original implementation

1.  Specifically, it adds a new method to the TraceSymbolTable class called create_from_df, which creates a symbol table from a DataFrame containing symbol names and their corresponding IDs. Changes to usage made in related files
2. The PR includes changes to the types.py file to add a new dataclass called GroupingPattern, which is used to group trace events based on a regular expression pattern.

Differential Revision: D69822786


