### PR TITLE
ATen Op associated kernels and overhead

### DIFF
--- a/hta/common/trace_symbol_table.py
+++ b/hta/common/trace_symbol_table.py
@@ -16,6 +16,7 @@ from hta.common.types import (
     CPU_EVENTS_CATEGORY_PATTERN,
     GroupingPattern,
     KERNEL_CATEGORY_PATTERN,
+    KERNEL_LAUNCH_CATEGORY_PATTERN,
     MemoryKernelGroupingPattern,
     ProfilerStepGroupingPattern,
 )
@@ -350,6 +351,9 @@ class TraceSymbolTable:
 
     def get_memory_name_ids(self) -> List[int]:
         return list(self.get_symbol_ids(MemoryKernelGroupingPattern).values())
+
+    def get_kernel_launch_ids(self) -> List[int]:
+        return list(self.get_symbol_ids(KERNEL_LAUNCH_CATEGORY_PATTERN).values())
 
 
 def decode_symbol_id_to_symbol_name(

--- a/hta/common/types.py
+++ b/hta/common/types.py
@@ -136,6 +136,12 @@ KERNEL_CATEGORY_PATTERN = GroupingPattern(
     re.compile("(kernel)|(gpu_mem.+)|(mtia_ccp_events)"), False, "GPU Kernels"
 )
 
+KERNEL_LAUNCH_CATEGORY_PATTERN = GroupingPattern(
+    re.compile(r"(cuda.*LaunchKernel)|(^runFunction)"),
+    inverse_match=False,
+    group_name="Kernel Launch",
+)
+
 CPU_OP_CATEGORY_PATTERN: GroupingPattern = GroupingPattern(
     re.compile("(cpu_op)|(user_annotation)"), False, "CPU Ops"
 )

--- a/hta/trace_analysis.py
+++ b/hta/trace_analysis.py
@@ -290,6 +290,37 @@ class TraceAnalysis:
             compress_other_kernels,
         )
 
+    def get_aten_op_kernels_and_delay(
+        self,
+        ranks: Optional[List[int]] = None,
+        sort_by: Optional[List[str]] = None,
+    ) -> Dict[int, pd.DataFrame]:
+        r"""
+        For each aten operator, this function finds the corresponding  kernels and the delay
+        between the aten operator and the first  kernel launch. The delay is measured in microseconds
+        (us). The delay is calculated as the difference between the start time of the aten operator
+        and the start time of the firs  kernel launch. The output is a table with the following columns:
+        Aten operator name, kernels associated with the aten operator, number of such aten op to kernel sequences,
+        delay between the aten operator and runtime launch of the first kernel, and the delay between the runtime
+        kernel launch to kernel execution on device.
+
+        Args:
+            ranks: the rank numbers on which the analysis was performed on
+            sort_by: the column name to sort the results by, default is "occurrence_count"
+
+        Returns:
+            Dict[int, pd.DataFrame]: The function returns a dictionary of dataframes. The key corresponds to the rank
+            and value is the DataFrame containing the path of kernels launch by aten op, the count number of each path,
+            the aten op launch delay and runtime delay.
+        """
+        if ranks is None:
+            ranks = [0]
+
+        if sort_by is None:
+            sort_by = ["occurrence_count"]
+
+        return CudaKernelAnalysis.get_aten_op_kernels_and_delay(self.t, ranks, sort_by)
+
     def get_cuda_kernel_launch_stats(
         self,
         ranks: Optional[List[int]] = None,

--- a/tests/test_trace_analysis.py
+++ b/tests/test_trace_analysis.py
@@ -119,6 +119,20 @@ class TraceAnalysisTestCase(unittest.TestCase):
         )
         self.assertTrue(frequent_patterns_dfs.empty)
 
+    def test_get_mtia_aten_op_kernels_and_delay_inference_single_rank(self):
+        dataframe_list = self.mtia_single_rank_trace_t.get_aten_op_kernels_and_delay(
+            sort_by=["occurrence_count", "avg_aten_op_launch_delay"]
+        )
+        rank_0_df = dataframe_list[0]
+        row = rank_0_df.iloc[0]
+        self.assertEqual(row["kernel_sequence"], "customized_fba_mul_const-dtype_Float")
+        self.assertEqual(row["aten_op_name"], "aten::mul")
+        self.assertEqual(row["occurrence_count"].item(), 822)
+        self.assertAlmostEqual(
+            row["avg_aten_op_launch_delay"].item(), 1092.545, delta=2.0
+        )
+        self.assertAlmostEqual(row["avg_runtime_delay"].item(), 293.113, delta=2.0)
+
     def test_get_cuda_kernel_launch_stats_training_multiple_ranks(self):
         dataframe_dict = self.vision_transformer_t.get_cuda_kernel_launch_stats(
             ranks=[1, 7], visualize=False


### PR DESCRIPTION
Summary:
With the request of MTIA runtime team, this diff aims to get a mapping op Aten Op to its associated kernels and corresponding Aten Op -> kernel launch delay and corresponding kernel launch delay -> device execution (we already had kernel launch delay -> device execution information before, thanks to fengxizhou).

More here: https://fburl.com/gdoc/qz5okx2z

Differential Revision: D73267800


