### PR TITLE
Add fallback for missing event_args_1.0.0.yaml to prevent runtime error

### DIFF
--- a/hta/configs/default_event_args.py
+++ b/hta/configs/default_event_args.py
@@ -1,0 +1,253 @@
+DEFAULT_EVENT_ARGS_YAML: str = """
+version: 1.0.0
+
+AVAILABLE_ARGS:
+  index::ev_idx:
+    name: ev_idx
+    raw_name: Ev Idx
+    value_type: Int
+    default_value: -1
+  index::external_id:
+    name: external_id
+    raw_name: External id
+    value_type: Int
+    default_value: -1
+  cpu_op::concrete_inputs:
+    name: concrete_inputs
+    raw_name: Concrete Inputs
+    value_type: Object
+    default_value: "[]"
+  cpu_op::fwd_thread:
+    name: fwd_thread_id
+    raw_name: Fwd thread id
+    value_type: Int
+    default_value: -1
+  cpu_op::input_dims:
+    name: input_dims
+    raw_name: Input Dims
+    value_type: Object
+    default_value: "-1"
+  cpu_op::input_type:
+    name: input_type
+    raw_name: Input type
+    value_type: Object
+    default_value: "-1"
+  cpu_op::input_strides:
+    name: input_strides
+    raw_name: Input Strides
+    value_type: Object
+    default_value: "-1"
+  cpu_op::sequence_number:
+    name: sequence
+    raw_name: Sequence number
+    value_type: Int
+    default_value: -1
+  cpu_op::kernel_backend:
+    name: kernel_backend
+    raw_name: kernel_backend
+    value_type: String
+    default_value: ""
+  cpu_op::kernel_hash:
+    name: kernel_hash
+    raw_name: kernel_hash
+    value_type: String
+    default_value: ""
+    min_supported_version: "1.1.0"
+  correlation::cbid:
+    name: cbid
+    raw_name: cbid
+    value_type: Int
+    default_value: -1
+  correlation::cpu_gpu:
+    name: correlation
+    raw_name: correlation
+    value_type: Int
+    default_value: -1
+  sm::blocks:
+    name: blocks_per_sm
+    raw_name: blocks per SM
+    value_type: Object
+    default_value: "[]"
+  sm::occupancy:
+    name: est_occupancy
+    raw_name: est. achieved occupancy %
+    value_type: Int
+    default_value: -1
+  sm::warps:
+    name: warps_per_sm
+    raw_name: warps per SM
+    value_type: Float
+    default_value: 0.0
+  data::bytes:
+    name: bytes
+    raw_name: bytes
+    value_type: Int
+    default_value: -1
+  data::bandwidth:
+    name: memory_bw_gbps
+    raw_name: memory bandwidth (GB/s)
+    value_type: Float
+    default_value: 0.0
+  cuda::context:
+    name: context
+    raw_name: context
+    value_type: Int
+    default_value: -1
+  cuda::device:
+    name: device
+    raw_name: device
+    value_type: Int
+    default_value: -1
+  cuda::stream:
+    name: stream
+    raw_name: stream
+    value_type: Int
+    default_value: -1
+  kernel::queued:
+    name: queued
+    raw_name: queued
+    value_type: Int
+    default_value: -1
+  kernel::shared_memory:
+    name: shared_memory
+    raw_name: shared memory
+    value_type: Int
+    default_value: -1
+  threads::block:
+    name: block
+    raw_name: block
+    value_type: Object
+    default_value: "[]"
+  threads::grid:
+    name: grid
+    raw_name: grid
+    value_type: Object
+    default_value: "[]"
+  threads::registers:
+    name: registers_per_thread
+    raw_name: registers per thread
+    value_type: Int
+    default_value: -1
+  cuda_sync::stream:
+    name: wait_on_stream
+    raw_name: wait_on_stream
+    value_type: Int
+    default_value: -1
+  cuda_sync::event:
+    name: wait_on_cuda_event_record_corr_id
+    raw_name: wait_on_cuda_event_record_corr_id
+    value_type: Int
+    default_value: -1
+  info::finished:
+    name: finished
+    raw_name: finished
+    value_type: String
+    default_value: ""
+  info::labels:
+    name: labels
+    raw_name: labels
+    value_type: String
+    default_value: ""
+  info::name:
+    name: name
+    raw_name: name
+    value_type: Int
+    default_value: -1
+  info::op_count:
+    name: op_count
+    raw_name: Op count
+    value_type: Int
+    default_value: -1
+  info::sort_index:
+    name: sort_index
+    raw_name: sort_index
+    value_type: Int
+    default_value: -1
+  nccl::collective_name:
+    name: collective_name
+    raw_name: Collective name
+    value_type: String
+    default_value: ""
+  nccl::in_msg_nelems:
+    name: in_msg_nelems
+    raw_name: In msg nelems
+    value_type: Int
+    default_value: 0
+  nccl::out_msg_nelems:
+    name: out_msg_nelems
+    raw_name: Out msg nelems
+    value_type: Int
+    default_value: 0
+  nccl::in_msg_size:
+    name: in_msg_size
+    raw_name: In msg size
+    value_type: Int
+    default_value: 0
+  nccl::out_msg_size:
+    name: out_msg_size
+    raw_name: Out msg size
+    value_type: Int
+    default_value: 0
+  nccl::group_size:
+    name: group_size
+    raw_name: Group size
+    value_type: Int
+    default_value: 0
+  nccl::dtype:
+    name: msg_dtype
+    raw_name: dtype
+    value_type: String
+    default_value: ""
+  nccl::in_split_size:
+    name: in_split_size
+    raw_name: In split size
+    value_type: Object
+    default_value: "[]"
+  nccl::out_split_size:
+    name: out_split_size
+    raw_name: Out split size
+    value_type: Object
+    default_value: "[]"
+  nccl::input_tensors_start:
+    name: input_tensors_start
+    raw_name: Input Tensors start
+    value_type: Object
+    default_value: "[]"
+    min_supported_version: "1.2.0"
+  nccl::output_tensors_start:
+    name: output_tensors_start
+    raw_name: Output Tensors start
+    value_type: Object
+    default_value: "[]"
+    min_supported_version: "1.2.0"
+  nccl::process_group_name:
+    name: process_group_name
+    raw_name: Process Group Name
+    value_type: String
+    default_value: ""
+  nccl::process_group_desc:
+    name: process_group_desc
+    raw_name: Process Group Description
+    value_type: String
+    default_value: ""
+  nccl::process_group_ranks:
+    name: process_group_ranks
+    raw_name: Process Group Ranks
+    value_type: Object
+    default_value: "[]"
+  nccl::rank:
+    name: process_rank
+    raw_name: Rank
+    value_type: Int
+    default_value: -1
+  inference::batch_size:
+    name: batch_size
+    raw_name: batchSize
+    value_type: Int
+    default_value: -1
+  inference::batch_id:
+    name: batch_id
+    raw_name: batchId
+    value_type: String
+    default_value: ""
+"""

--- a/hta/configs/event_args_yaml_parser.py
+++ b/hta/configs/event_args_yaml_parser.py
@@ -3,12 +3,13 @@
 # pyre-strict
 
 
+import os
 from functools import lru_cache
 from pathlib import Path
 from typing import Callable, Dict, List
 
 import yaml
-
+from hta.configs.default_event_args import DEFAULT_EVENT_ARGS_YAML
 from hta.configs.default_values import AttributeSpec, EventArgs, ValueType, YamlVersion
 
 
@@ -84,8 +85,11 @@ def parse_event_args_yaml(version: YamlVersion) -> EventArgs:
     yaml_file = f"event_args_{version.get_version_str()}.yaml"
     local_yaml_data_filepath = str(pkg_path.joinpath("event_args_formats", yaml_file))
 
-    with open(local_yaml_data_filepath, "r") as f:
-        yaml_content = yaml.safe_load(f)
+    if os.path.exists(local_yaml_data_filepath):
+        with open(local_yaml_data_filepath, "r") as f:
+            yaml_content = yaml.safe_load(f)
+    else:
+        yaml_content = yaml.safe_load(DEFAULT_EVENT_ARGS_YAML)
 
     def parse_value_type(value: str) -> ValueType:
         return ValueType[value]

--- a/tests/test_parser_config.py
+++ b/tests/test_parser_config.py
@@ -1,9 +1,10 @@
 import unittest
 from typing import Dict, List, NamedTuple, Optional
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 
-from hta.configs.default_values import ValueType, YamlVersion
+from hta.configs.default_values import EventArgs, ValueType, YamlVersion
 from hta.configs.event_args_yaml_parser import parse_event_args_yaml
 from hta.configs.parser_config import (
     AttributeSpec,
@@ -15,6 +16,7 @@ from hta.configs.parser_config import (
 from hta.utils.test_utils import data_provider
 
 _MODULE_NAME = "hta.configs.parser_config"
+_MODULE_NAME_YAML = "hta.configs.event_args_yaml_parser"
 
 
 class ParserConfigTestCase(unittest.TestCase):
@@ -266,3 +268,24 @@ class ParserConfigTestCase(unittest.TestCase):
         # Run the following two steps purely for test coverage
         ParserConfig.show_available_args()
         ParserConfig.get_info_args()
+
+
+class TestParseEventArgsYaml(unittest.TestCase):
+    @data_provider(
+        lambda: (
+            {
+                "file_exists": True,
+            },
+            {
+                "file_exists": False,
+            },
+        )
+    )
+    @patch(f"{_MODULE_NAME_YAML}.os.path.exists")
+    def test_parse_event_args_yaml(
+        self, mock_file_exists: MagicMock, file_exists: bool
+    ) -> None:
+        mock_file_exists.return_value = file_exists
+        version = YamlVersion.from_string("1.0.0")
+        result = parse_event_args_yaml(version)
+        self.assertIsInstance(result, EventArgs)


### PR DESCRIPTION
Summary:
This diff adds a fallback mechanism in case the file
hta/configs/event_args_formats/event_args_1.0.0.yaml is not correctly included in the BUCK or TARGET's resources definition.

Without this, attempting to access the file may raise the following error at runtime:

```
  File "ads_training/p9e/open_hta/hta/common/trace_parser.py", line 26, in <module>
  File "hta/configs/parser_config.py", line 39, in <module>
  File "hta/configs/event_args_yaml_parser.py", line 87, in parse_event_args_yaml
NotADirectoryError: [Errno 20] Not a directory: '/proc/self/fd/6/hta/configs/event_args_formats/event_args_1.0.0.yaml'
```

Differential Revision: D73468457


