### PR TITLE
make op kernels and delay generalized

### DIFF
--- a/hta/analyzers/cuda_kernel_analysis.py
+++ b/hta/analyzers/cuda_kernel_analysis.py
@@ -318,25 +318,25 @@ class CudaKernelAnalysis:
         return raw_trace_content
 
     @classmethod
-    def visualize_aten_op_kernels_and_overhead(cls, rank: int, df: pd.DataFrame):
+    def visualize_op_kernels_and_overhead(cls, rank: int, df: pd.DataFrame):
         fig = go.Figure(
             data=[
                 go.Table(
                     header={
                         "values": [
-                            "ATen Operation",
+                            "Operation",
                             "Kernel Sequence",
                             "Occurrence Count",
-                            "Average ATen Op Launch Delay (us)",
+                            "Average Op Launch Delay (us)",
                             "Average Runtime Delay (us)",
                         ]
                     },
                     cells={
                         "values": [
-                            df["aten_op_name"],
+                            df["op_name"],
                             df["kernel_sequence"],
                             df["occurrence_count"],
-                            df["avg_aten_op_launch_delay"],
+                            df["avg_op_launch_delay"],
                             df["avg_runtime_delay"],
                         ],
                         "height": 30,
@@ -346,8 +346,7 @@ class CudaKernelAnalysis:
             ]
         )
         fig.update_layout(
-            title="ATen Operations, Associated Kernels, ATen and Runtime Delays for Rank %s"
-            % rank,
+            title="Ops, Associated Kernels, Op and Runtime Delays for Rank %s" % rank,
             width=1500,
             height=1500,
             autosize=True,
@@ -402,15 +401,16 @@ class CudaKernelAnalysis:
         fig3.show()
 
     @classmethod
-    def get_aten_op_kernels_and_delay(
+    def get_op_kernels_and_delay(
         cls,
         trace: Trace,
+        op_name_pattern: Optional[str] = None,
         ranks: Optional[List[int]] = None,
         sort_by: Optional[List[str]] = None,
     ) -> Dict[int, pd.DataFrame]:
         """
-        Get ATen op launch statistics.
-        This function gives information about what kernels are launched by each ATen op, their count number, aten op launch delay and runtime delay.
+        Get op launch statistics.
+        This function gives information about what kernels are launched by each op, their count number, op launch delay and runtime delay.
 
         Args:
             ranks: the rank numbers on which the analysis was performed on
@@ -418,8 +418,8 @@ class CudaKernelAnalysis:
 
         Returns:
             Dict[int, pd.DataFrame]:: The function returns a dictionary of dataframes. The key corresponds to the rank
-            and value is the DataFrame containing the path of kernels launch by aten op, the count number of each path,
-            the aten op launch delay and runtime delay.
+            and value is the DataFrame containing the path of kernels launch by op, the count number of each path,
+            the op launch delay and runtime delay.
         """
         if not ranks:
             ranks = [0]
@@ -427,16 +427,19 @@ class CudaKernelAnalysis:
         if not sort_by:
             sort_by = ["occurrence_count"]
 
+        if not op_name_pattern:
+            op_name_pattern = "aten::"
+
         symbol_table = trace.symbol_table
         launch_stats = []
 
-        def find_deepest_aten_op(
-            runtime_start: int, runtime_end: int, aten_operations: pd.DataFrame
+        def find_deepest_op(
+            runtime_start: int, runtime_end: int, operations: pd.DataFrame
         ) -> Optional[pd.Series]:
-            """Find the most deeply nested ATen op that fully wraps the entire runtime event."""
-            matching_ops = aten_operations[
-                (aten_operations["ts"] <= runtime_start)
-                & ((aten_operations["ts"] + aten_operations["dur"]) >= runtime_end)
+            """Find the most deeply nested op that fully wraps the entire runtime event."""
+            matching_ops = operations[
+                (operations["ts"] <= runtime_start)
+                & ((operations["ts"] + operations["dur"]) >= runtime_end)
             ]
             if matching_ops.empty:
                 return None
@@ -446,10 +449,10 @@ class CudaKernelAnalysis:
         for rank in ranks:
             trace_data = trace.get_trace(rank)
             symbol_table.decode_df(trace.traces[rank], create_new_columns=True)
-            aten_operations = trace_data[
-                trace_data["s_name"].str.startswith("aten::")
+            operations = trace_data[
+                trace_data["s_name"].str.startswith(op_name_pattern)
             ].copy()
-            aten_operations = aten_operations[["tid", "s_name", "ts", "dur"]]
+            operations = operations[["tid", "s_name", "ts", "dur"]]
 
             runtime_launch_events = trace_data[
                 trace_data["name"].isin(symbol_table.get_kernel_launch_ids())
@@ -458,10 +461,10 @@ class CudaKernelAnalysis:
             kernels = trace_data[trace_data["stream"] != -1].copy()
 
             for _, event in runtime_launch_events.iterrows():
-                deepest_op = find_deepest_aten_op(
+                deepest_op = find_deepest_op(
                     event["ts"],
                     event["ts"] + event["dur"],
-                    aten_operations,
+                    operations,
                 )
                 if deepest_op is not None:
                     kernel_event = kernels[
@@ -470,17 +473,17 @@ class CudaKernelAnalysis:
                     if len(kernel_event) > 1:
                         print("Error: multiple kernel events found for correlation id")
                     if kernel_event is not None:
-                        aten_op_delay = event["ts"] - deepest_op["ts"]
+                        op_delay = event["ts"] - deepest_op["ts"]
                         runtime_delay = kernel_event["ts"].item() - event["ts"]
 
                         launch_stats.append(
                             {
                                 "thread_id": deepest_op["tid"],
-                                "aten_op_name": deepest_op["s_name"],
-                                "aten_op_start": deepest_op["ts"],
+                                "op_name": deepest_op["s_name"],
+                                "op_start": deepest_op["ts"],
                                 "runtime_start": event["ts"],
                                 "device_start": kernel_event["ts"].item(),
-                                "aten_op_delay": aten_op_delay,
+                                "op_delay": op_delay,
                                 "runtime_delay": runtime_delay,
                                 "correlation_id": event["correlation"],
                                 "kernel_name": kernel_event["s_name"].item(),
@@ -489,12 +492,12 @@ class CudaKernelAnalysis:
             stats_df = pd.DataFrame(launch_stats)
 
             grouped_stats = (
-                stats_df.groupby(["thread_id", "aten_op_name", "aten_op_start"])
+                stats_df.groupby(["thread_id", "op_name", "op_start"])
                 .agg(
                     {
                         "kernel_name": list,
                         "correlation_id": list,
-                        "aten_op_delay": list,
+                        "op_delay": list,
                         "runtime_delay": list,
                     }
                 )
@@ -506,7 +509,7 @@ class CudaKernelAnalysis:
             grouped_stats["correlation_ids"] = grouped_stats["correlation_id"].apply(
                 lambda x: ", ".join(map(str, x))
             )
-            grouped_stats["first_launch_delay"] = grouped_stats["aten_op_delay"].apply(
+            grouped_stats["first_launch_delay"] = grouped_stats["op_delay"].apply(
                 lambda x: x[0]
             )
             grouped_stats["first_runtime_delay"] = grouped_stats["runtime_delay"].apply(
@@ -514,22 +517,22 @@ class CudaKernelAnalysis:
             )
 
             final_stats = (
-                grouped_stats.groupby(["aten_op_name", "kernel_sequence"])
+                grouped_stats.groupby(["op_name", "kernel_sequence"])
                 .agg(
                     occurrence_count=("first_runtime_delay", "count"),
-                    avg_aten_op_launch_delay=("first_launch_delay", "mean"),
+                    avg_op_launch_delay=("first_launch_delay", "mean"),
                     avg_runtime_delay=("first_runtime_delay", "mean"),
                 )
                 .reset_index()
             ).sort_values(sort_by, ascending=False)
 
             final_stats["avg_runtime_delay"] = final_stats["avg_runtime_delay"].round(3)
-            final_stats["avg_aten_op_launch_delay"] = final_stats[
-                "avg_aten_op_launch_delay"
+            final_stats["avg_op_launch_delay"] = final_stats[
+                "avg_op_launch_delay"
             ].round(3)
 
             result_dict[rank] = final_stats
-            cls.visualize_aten_op_kernels_and_overhead(rank, final_stats)
+            cls.visualize_op_kernels_and_overhead(rank, final_stats)
 
         return result_dict
 

--- a/hta/trace_analysis.py
+++ b/hta/trace_analysis.py
@@ -290,28 +290,29 @@ class TraceAnalysis:
             compress_other_kernels,
         )
 
-    def get_aten_op_kernels_and_delay(
+    def get_op_kernels_and_delay(
         self,
+        op_name_pattern: Optional[str] = None,
         ranks: Optional[List[int]] = None,
         sort_by: Optional[List[str]] = None,
     ) -> Dict[int, pd.DataFrame]:
         r"""
-        For each aten operator, this function finds the corresponding  kernels and the delay
-        between the aten operator and the first  kernel launch. The delay is measured in microseconds
-        (us). The delay is calculated as the difference between the start time of the aten operator
-        and the start time of the firs  kernel launch. The output is a table with the following columns:
-        Aten operator name, kernels associated with the aten operator, number of such aten op to kernel sequences,
-        delay between the aten operator and runtime launch of the first kernel, and the delay between the runtime
-        kernel launch to kernel execution on device.
+           For each operator, this function finds the corresponding  kernels and the delay
+           between the operator and the first  kernel launch. The delay is measured in microseconds
+           (us). The delay is calculated as the difference between the start time of the operator
+           and the start time of the firs  kernel launch. The output is a table with the following columns:
+        operator name, kernels associated with the operator, number of such op to kernel sequences,
+           delay between the operator and runtime launch of the first kernel, and the delay between the runtime
+           kernel launch to kernel execution on device.
 
-        Args:
-            ranks: the rank numbers on which the analysis was performed on
-            sort_by: the column name to sort the results by, default is "occurrence_count"
+           Args:
+               ranks: the rank numbers on which the analysis was performed on
+               sort_by: the column name to sort the results by, default is "occurrence_count"
 
-        Returns:
-            Dict[int, pd.DataFrame]: The function returns a dictionary of dataframes. The key corresponds to the rank
-            and value is the DataFrame containing the path of kernels launch by aten op, the count number of each path,
-            the aten op launch delay and runtime delay.
+           Returns:
+               Dict[int, pd.DataFrame]: The function returns a dictionary of dataframes. The key corresponds to the rank
+               and value is the DataFrame containing the path of kernels launch by op, the count number of each path,
+               the op launch delay and runtime delay.
         """
         if ranks is None:
             ranks = [0]
@@ -319,7 +320,12 @@ class TraceAnalysis:
         if sort_by is None:
             sort_by = ["occurrence_count"]
 
-        return CudaKernelAnalysis.get_aten_op_kernels_and_delay(self.t, ranks, sort_by)
+        if op_name_pattern is None:
+            op_name_pattern = "::aten"
+
+        return CudaKernelAnalysis.get_op_kernels_and_delay(
+            self.t, op_name_pattern, ranks, sort_by
+        )
 
     def get_cuda_kernel_launch_stats(
         self,

--- a/tests/test_trace_analysis.py
+++ b/tests/test_trace_analysis.py
@@ -120,7 +120,7 @@ class TraceAnalysisTestCase(unittest.TestCase):
         self.assertTrue(frequent_patterns_dfs.empty)
 
     def test_get_mtia_aten_op_kernels_and_delay_inference_single_rank(self):
-        dataframe_list = self.mtia_single_rank_trace_t.get_aten_op_kernels_and_delay(
+        dataframe_list = self.mtia_single_rank_trace_t.get_op_kernels_and_delay(
             sort_by=["occurrence_count", "avg_aten_op_launch_delay"]
         )
         rank_0_df = dataframe_list[0]


### PR DESCRIPTION
Summary: `get_aten_op_kernels_and_delay`  was added in D73267800 that allowed obtianing ssociated kernels related to Aten Op and Aten Op overhead. We wish to make it generalized for other ops as well. So, we let the users specify op_name_pattern and default to "aten::" when none is provided

Differential Revision: D73855981


