### PR TITLE
Add cuLaunchKernel into kernel launch category

### DIFF
--- a/hta/common/types.py
+++ b/hta/common/types.py
@@ -137,7 +137,7 @@ KERNEL_CATEGORY_PATTERN = GroupingPattern(
 )
 
 KERNEL_LAUNCH_CATEGORY_PATTERN = GroupingPattern(
-    re.compile(r"(cuda.*LaunchKernel)|(^runFunction)"),
+    re.compile(r"(cuda.*LaunchKernel)|(cuLaunchKernel)|(^runFunction)"),
     inverse_match=False,
     group_name="Kernel Launch",
 )


### PR DESCRIPTION
Summary: This commit extends kernel launch event pattern to include "cuLaunchKernel". "cuLaunchKernel" is a driver level API that launches CUDA kernel, it could be invoked by the higher level runtime API "cudaLaunchkernel". So this event should also be categorized as kernel launch event.


Differential Revision: D74435656


