### PR TITLE
Allow filtering of flow events in the trace

### DIFF
--- a/hta/analyzers/critical_path_analysis.py
+++ b/hta/analyzers/critical_path_analysis.py
@@ -1641,7 +1641,7 @@ class CriticalPathAnalysis:
         show_all_edges: bool,
         edge_types_to_viz: Optional[Set[CPEdgeType]] = None,
     ) -> str:
-        f"""
+        r"""
         Overlay the identified critical path on top of the trace file
         for visualization.
 
@@ -1660,7 +1660,8 @@ class CriticalPathAnalysis:
                 if only_show_critical_events is True.
                 Default value = False.
             edge_types_to_viz (Set): types of edges to add to the overlaid trace.
-                Default is {DEFAULT_EDGE_TYPES_IN_VIZ}
+                By default we only include Kernel launch edges and CPU/GPU sync
+                dependency edges.
 
         Returns: the overlaid_trace_file path.
 
@@ -1742,10 +1743,11 @@ class CriticalPathAnalysis:
                     if not CriticalPathAnalysis._is_zero_weight_launch_edge(e)
                 )
         else:
-            edges = (e for e in critical_path_graph.critical_path_edges_set)
-
-        if not show_all_edges:
-            edges = (e for e in edges if e in DEFAULT_EDGE_TYPES_IN_VIZ)
+            edges = (
+                e
+                for e in critical_path_graph.critical_path_edges_set
+                if e.type in edge_types_to_viz
+            )
 
         for e in edges:
             u, v = e.begin, e.end


### PR DESCRIPTION
# Summary
Updates critical path analysis overlaid trace to only show important flow/edges.
This includes edges for kernel launch, and CPU/GPU synchronization. 

The goal is to reduce strain on trace visualization tools to show high number of edges.

## Test updates
* Refactor and split up tests in critical path analysis
* Add helper functions to make the overlaid trace test a lot more readable.

## Unit Test
```
pytest tests/test_critical_path_analysis.py
```

## Example
Re-ran simple add trace and we can now only see the kernel launch edge in overlaid trace
![Screenshot 2025-05-16 at 3 46 30 PM](https://github.com/user-attachments/assets/7ba04af3-7da9-45b7-9fd3-504dfb170495)
![Screenshot 2025-05-16 at 3 46 45 PM](https://github.com/user-attachments/assets/0df01bf5-cfdc-4ee9-87fc-256896d40e8c)


## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [] N/A
- [x] Did you make sure to update the docs?
  - [ ] N/A
- [x] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [] N/A
