### PR TITLE
When displaying flow events in the overlay trace, merge edge types into single 'critical_path' for simplicity

### DIFF
--- a/hta/analyzers/critical_path_analysis.py
+++ b/hta/analyzers/critical_path_analysis.py
@@ -1759,10 +1759,11 @@ class CriticalPathAnalysis:
                 ),
                 is_start=is_start,
                 name="critical_path",
-                cat=str(edge.type.value),
+                cat="critical_path",
                 args={
                     "weight": int(edge.weight),
                     "critical": is_critical,
+                    "type": str(edge.type.value),
                 },
             )
 

--- a/hta/analyzers/critical_path_analysis.py
+++ b/hta/analyzers/critical_path_analysis.py
@@ -181,9 +181,6 @@ class CPGraph(nx.DiGraph):
         self.t = t
         self.t_full = t_full
         self.full_trace_df: pd.DataFrame = self.t_full.get_trace(rank)
-        self.sym_table = (
-            t_full.symbol_table.get_sym_table()
-        )  # List of symbols, where index is the symbol ID
         self.symbol_table = t_full.symbol_table
 
         # init networkx DiGraph
@@ -340,7 +337,7 @@ class CPGraph(nx.DiGraph):
         if ev_id < 0:
             return "ROOT"
         name_id = self.trace_df.name.loc[ev_id]
-        return self.sym_table[name_id]
+        return self.symbol_table.get_sym_table()[name_id]
 
     def get_nodes_for_event(
         self, ev_id: int


### PR DESCRIPTION
Summary: See T227835444

Reviewed By: seansundor

Differential Revision: D77028171


