### PR TITLE
Bugfix: use e[args][type] instead of e[cat] to get the edge type, since it was changed recently

### DIFF
--- a/tests/test_critical_path_analysis.py
+++ b/tests/test_critical_path_analysis.py
@@ -251,7 +251,11 @@ class CriticalPathAnalysisTestCase(unittest.TestCase):
                 if "args" in e and e["ph"] == "f"
             )
             stats.edge_count_per_type = Counter(
-                e["cat"] for e in trace_events if "critical_path" in e.get("cat", "")
+                e["args"]["type"]
+                for e in trace_events
+                if "args" in e
+                and "type" in e["args"]
+                and "critical_path" in e["args"]["type"]
             )
 
         return stats


### PR DESCRIPTION
Summary:
I previously submitted D77028171, but this broke test_critical_path_overlaid_trace.

Seems like I forgot to run the unit tests after making that change.

Simple fix: that diff moved the edge type from e["cat"] to e["args"]["type"]. Re-ran the test and it now passes.

Reviewed By: VieEeEw

Differential Revision: D77677065


