### PR TITLE
Trim event duration based on tree hierarchy in CallGraph lib

### DIFF
--- a/hta/common/call_stack.py
+++ b/hta/common/call_stack.py
@@ -4,6 +4,7 @@
 
 import functools
 import logging
+import queue
 from collections import namedtuple
 from enum import Enum
 from time import perf_counter
@@ -208,11 +209,13 @@ class CallStackGraph:
         self,
         df: pd.DataFrame,
         identity: CallStackIdentity,
+        sym_table: List[str],
         filter_func: Optional[Filter] = None,
     ) -> None:
         """Construct an empty graph."""
         self.df = df
         self.identity: CallStackIdentity = identity
+        self.sym_table: List[str] = sym_table
         self.device_type: DeviceType = infer_device_type(df)
         self.nodes: Dict[int, CallStackNode] = {}
         self.correlations: pd.Series = None
@@ -462,6 +465,7 @@ class CallGraph:
         ranks: Optional[List[int]] = None,
         filter_func: Optional[Filter] = None,
         remapped_tids: Dict[int, Dict[int, int]] | None = None,
+        pre_process_trace_data: bool = False,
     ) -> None:
         """Construct a CallGraph from a Trace object <trace_data>
 
@@ -472,12 +476,14 @@ class CallGraph:
             remapped_tids (Dict[Dict[int, int]]) : a dictionary that stores per-rank thread ID remappings.
                 For example: { 0: { 300: 400}} means that on rank 0, thread ID 300 is remapped to 400.
                 This is useful for training jobs, where the backward thread can typically be merged into the main trainer thread.
+            pre_process_trace_data (bool) : whether to pre-process the trace data. If True, the event duration from trace data will be trimmed to not exceed the duration of the parent event if exist.
         Raises:
             ValueError: the trace data is invalid.
         """
         self.trace_data: Trace = trace
         self.mapping: pd.DataFrame = pd.DataFrame()
         self.call_stacks: List[CallStackGraph] = []
+        self.pre_process_trace_data = pre_process_trace_data
 
         _ranks = [k for k in trace.get_all_traces()] if ranks is None else ranks
         self._construct_call_graph(_ranks, filter_func, remapped_tids)
@@ -517,6 +523,8 @@ class CallGraph:
         t0 = perf_counter()
         # construct a call stack graph for each thread/stream
         for rank in ranks:
+            if self.pre_process_trace_data:
+                self.trim_trace_events(self.trace_data.get_trace(rank))
             df = self.trace_data.get_trace(rank).copy()
             if remapped_tids and rank in remapped_tids:
                 df = self._remap_tids(df, remapped_tids[rank])
@@ -525,7 +533,12 @@ class CallGraph:
                     # Filter out gpu annotations and sync events
                     df_thread = df_thread[df_thread["stream"].gt(0)]
                 csi = CallStackIdentity(rank, pid, tid)
-                csg = CallStackGraph(df_thread, csi, filter_func)
+                csg = CallStackGraph(
+                    df_thread,
+                    csi,
+                    self.trace_data.symbol_table.get_sym_table(),
+                    filter_func,
+                )
                 self.call_stacks.append(csg)
                 call_stack_ids.append(csi)
         t1 = perf_counter()
@@ -607,3 +620,44 @@ class CallGraph:
         stack_nodes = np.array(leaf_nodes + parent_nodes + kernel_nodes)
         df_stack = df.reindex(stack_nodes)
         return df_stack
+
+    def trim_trace_events(self, df: pd.DataFrame) -> None:
+        """Trim the trace events to not exceed the duration of the parent event if exist. The original DataFrame is modified in place.
+
+        Args:
+            df (pd.DataFrame): the trace data frame.
+        """
+        adj: Dict[int, List[int]] = {}
+        python_id_event_idx_map: Dict[int, int] = {}
+        roots = []
+        for row in df.itertuples():
+            if hasattr(row, "python_id") and row.python_id > -1:
+                python_id_event_idx_map[row.python_id] = row.index
+                if (
+                    hasattr(row, "python_parent_id")
+                    and row.python_parent_id > -1
+                    and df.loc[python_id_event_idx_map[row.python_parent_id]]["tid"]
+                    == row.tid
+                ):
+                    children = adj.get(row.python_parent_id, [])
+                    children.append(row.python_id)
+                    adj[row.python_parent_id] = children
+                else:
+                    roots.append(row.python_id)
+        for root in roots:
+            # BFS trim event duration
+            q = queue.Queue()
+            q.put(root)
+            while not q.empty():
+                cur_py_id = q.get()
+                if cur_py_id in adj:
+                    cur_id = python_id_event_idx_map[cur_py_id]
+                    for child_py_id in adj[cur_py_id]:
+                        child_id = python_id_event_idx_map[child_py_id]
+                        df.at[child_id, "dur"] = min(
+                            df.at[child_id, "dur"],
+                            df.at[cur_id, "ts"]
+                            + df.at[cur_id, "dur"]
+                            - df.at[child_id, "ts"],
+                        )
+                        q.put(child_py_id)

--- a/hta/configs/event_args_formats/event_args_1.0.0.yaml
+++ b/hta/configs/event_args_formats/event_args_1.0.0.yaml
@@ -11,6 +11,16 @@ AVAILABLE_ARGS:
     raw_name: External id
     value_type: Int
     default_value: -1
+  index::python_id:
+    name: python_id
+    raw_name: Python id
+    value_type: Int
+    default_value: -1
+  index::python_parent_id:
+    name: python_parent_id
+    raw_name: Python parent id
+    value_type: Int
+    default_value: -1
   cpu_op::concrete_inputs:
     name: concrete_inputs
     raw_name: Concrete Inputs

--- a/hta/configs/event_args_yaml_parser.py
+++ b/hta/configs/event_args_yaml_parser.py
@@ -17,6 +17,11 @@ from hta.configs.default_values import AttributeSpec, EventArgs, ValueType, Yaml
 v1_0_0: YamlVersion = YamlVersion(1, 0, 0)
 
 
+ARGS_INDEX_FUNC: Callable[[Dict[str, AttributeSpec]], List[AttributeSpec]] = (
+    lambda available_args: [
+        available_args[k] for k in ["index::external_id", "index::python_id"]
+    ]
+)
 ARGS_INPUT_SHAPE_FUNC: Callable[[Dict[str, AttributeSpec]], List[AttributeSpec]] = (
     lambda available_args: [
         available_args[k]
@@ -74,7 +79,7 @@ ARGS_DEFAULT_FUNC: Callable[[Dict[str, AttributeSpec]], List[AttributeSpec]] = (
         + ARGS_BANDWIDTH_FUNC(available_args)
         + ARGS_SYNC_FUNC(available_args)
         + ARGS_INPUT_SHAPE_FUNC(available_args)
-        + [available_args["index::external_id"]]
+        + ARGS_INDEX_FUNC(available_args)
     )
 )
 

--- a/tests/test_call_stack.py
+++ b/tests/test_call_stack.py
@@ -1,12 +1,18 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+# Unit tests for call_stack.py
 
 import unittest
 
 import pandas as pd
 
-from hta.common.call_stack import CallStackGraph, CallStackIdentity, CallStackNode
+from hta.common.call_stack import (
+    CallGraph,
+    CallStackGraph,
+    CallStackIdentity,
+    CallStackNode,
+)
 from hta.common.trace_filter import ZeroDurationFilter
 
 
@@ -22,6 +28,7 @@ class CallStackTestCase(unittest.TestCase):
                 "tid": [2, 2, 2, 2, 2, 2, 2, 2, 2],
                 "stream": [-1, -1, -1, -1, -1, -1, -1, -1, -1],
                 "index_correlation": [-1, -1, -1, -1, -1, -1, -1, -1, -1],
+                "name": [0, 1, 0, 1, 0, 1, 0, 1, 0],
             }
         )
         self.csi = CallStackIdentity(0, 1, 2)
@@ -55,6 +62,7 @@ class CallStackTestCase(unittest.TestCase):
                 "tid": [3, 3, 3, 3, 3, 3],
                 "stream": [-1, -1, -1, -1, -1, -1],
                 "index_correlation": [-1, -1, -1, -1, -1, -1],
+                "name": [0, 1, 0, 1, 0, 1],
             }
         )
         self.csi2 = CallStackIdentity(0, 1, 3)
@@ -69,23 +77,27 @@ class CallStackTestCase(unittest.TestCase):
             4: CallStackNode(parent=0, depth=1, children=[5]),
             5: CallStackNode(parent=4, depth=2, children=[]),
         }
+        self.symbol_table = ["name1", "name2"]
 
     def test_construct_call_graph(self):
-        csg = CallStackGraph(self.df1, self.csi)
+        csg = CallStackGraph(self.df1, self.csi, self.symbol_table)
         nodes = csg.get_nodes()
         self.assertDictEqual(nodes, self.nodes)
 
     def test_construct_call_graph_0_dur(self):
-        csg = CallStackGraph(self.df2, self.csi2, filter_func=ZeroDurationFilter)
+        csg = CallStackGraph(
+            self.df2, self.csi2, self.symbol_table, filter_func=ZeroDurationFilter
+        )
         nodes = csg.get_nodes()
         self.assertDictEqual(nodes, self.nodes2)
 
     def test_sort_events(self):
-        index = [1, 2, 3, 4]
+        index = [0, 1, 2, 3]
         start = [0, 0, 5, 5]
         dur = [10, 5, 1, 5]
         stream = [-1, -1, -1, -1]
         cor = [-1, -1, -1, -1]
+        name = [0, 0, 0, 0]
         df = pd.DataFrame(
             {
                 "index": index,
@@ -93,43 +105,213 @@ class CallStackTestCase(unittest.TestCase):
                 "dur": dur,
                 "stream": stream,
                 "index_correlation": cor,
+                "name": name,
             }
         )
         nodes = {
-            -1: CallStackNode(parent=-1, depth=-1, children=[1]),
-            1: CallStackNode(parent=-1, depth=0, children=[2, 4]),
-            2: CallStackNode(parent=1, depth=1, children=[]),
-            4: CallStackNode(parent=1, depth=1, children=[3]),
-            3: CallStackNode(parent=4, depth=2, children=[]),
+            -1: CallStackNode(parent=-1, depth=-1, children=[0]),
+            0: CallStackNode(parent=-1, depth=0, children=[1, 3]),
+            1: CallStackNode(parent=0, depth=1, children=[]),
+            2: CallStackNode(parent=3, depth=2, children=[]),
+            3: CallStackNode(parent=0, depth=1, children=[2]),
         }
-        csg = CallStackGraph(df, self.csi)
+        csg = CallStackGraph(df, self.csi, self.symbol_table)
         self.assertDictEqual(nodes, csg.get_nodes())
 
     def test_get_path_to_root(self):
-        csg = CallStackGraph(self.df1, self.csi)
+        csg = CallStackGraph(self.df1, self.csi, self.symbol_table)
         self.assertListEqual(csg.get_path_to_root(2), self.path_to_root_of_2)
         self.assertListEqual(csg.get_path_to_root(3), self.path_to_root_of_3)
         self.assertListEqual(csg.get_path_to_root(5), self.path_to_root_of_5)
 
     def test_get_leaf_nodes(self):
-        csg = CallStackGraph(self.df1, self.csi)
+        csg = CallStackGraph(self.df1, self.csi, self.symbol_table)
         self.assertListEqual(csg.get_leaf_nodes(0), self.leaf_nodes_of_0)
         self.assertListEqual(csg.get_leaf_nodes(4), self.leaf_nodes_of_4)
         self.assertListEqual(csg.get_leaf_nodes(5), self.leaf_nodes_of_5)
 
     def test_get_paths_to_leaves(self):
-        csg = CallStackGraph(self.df1, self.csi)
+        csg = CallStackGraph(self.df1, self.csi, self.symbol_table)
         self.assertListEqual(csg.get_paths_to_leaves(0), self.paths_to_leaves_of_0)
         self.assertListEqual(csg.get_paths_to_leaves(5), [self.leaf_nodes_of_5])
 
     def test_node_depth(self):
-        csg = CallStackGraph(self.df1, self.csi)
+        csg = CallStackGraph(self.df1, self.csi, self.symbol_table)
         nodes = csg.get_nodes()
         df = csg.get_dataframe()
 
         depth_from_csg = csg.get_depth().to_dict()
         depth_from_nodes = {idx: node.depth for idx, node in nodes.items() if idx >= 0}
         self.assertDictEqual(depth_from_csg, depth_from_nodes)
+        # Verify df is used
+        self.assertIsNotNone(df)
+
+
+class CallGraphTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        # Mock Trace class for testing
+        class MockTrace:
+            def __init__(self, traces):
+                self.traces = traces
+
+            def get_all_traces(self):
+                return self.traces.keys()
+
+            def get_trace(self, rank):
+                return self.traces[rank]
+
+            class MockSymbolTable:
+                def get_sym_table(self):
+                    return ["symbol1", "symbol2"]
+
+            symbol_table = MockSymbolTable()
+
+        # Create test data for trim_trace_events
+        self.df_trim = pd.DataFrame(
+            {
+                "index": [0, 1, 2, 3],
+                "ts": [0, 2, 4, 6],
+                "dur": [10, 6, 8, 2],  # Child event 2 exceeds parent event 1's duration
+                "pid": [1, 1, 1, 1],
+                "tid": [1, 1, 1, 1],
+                "stream": [-1, -1, -1, -1],
+                "index_correlation": [-1, -1, -1, -1],
+                "python_id": [100, 101, 102, 103],
+                "python_parent_id": [-1, 100, 101, 102],
+                "name": [0, 0, 0, 0],
+            }
+        )
+
+        self.trace_mock = MockTrace({0: self.df_trim})
+
+    def test_trim_trace_events_basic(self):
+        # Given & when
+        CallGraph(self.trace_mock, pre_process_trace_data=True)
+
+        # Then
+        # Event 1: ts=2, dur=6, end=8
+        # Event 2: ts=4, dur=8 (original), should be trimmed to dur=4 to end at 8
+        self.assertEqual(self.df_trim.at[2, "dur"], 4)
+
+    def test_trim_trace_events_complex_hierarchy(self):
+        # Given
+        df_complex = pd.DataFrame(
+            {
+                "index": [0, 1, 2, 3, 4],
+                "ts": [0, 2, 4, 6, 7],
+                "dur": [15, 10, 10, 20, 8],
+                "pid": [1, 1, 1, 1, 1],
+                "tid": [1, 1, 1, 1, 1],
+                "stream": [-1, -1, -1, -1, -1],
+                "index_correlation": [-1, -1, -1, -1, -1],
+                "python_id": [100, 101, 102, 103, 104],
+                "python_parent_id": [-1, 100, 101, 102, 102],
+                "name": [0, 0, 0, 0, 0],
+            }
+        )
+
+        trace_complex = type(self.trace_mock)({0: df_complex})
+
+        # When
+        CallGraph(trace_complex, pre_process_trace_data=True)
+
+        # Then
+        # Event 1: ts=2, dur=10, end=12
+        # Event 2: ts=4, dur=10, should be trimmed to dur=8 to end at 12
+        # Event 3: ts=6, dur=20, should be trimmed to dur=6 to end at 12
+        # Event 4: ts=7, dur=8, should be trimmed to dur=5 to end at 12
+        self.assertEqual(df_complex.at[2, "dur"], 8)
+        self.assertEqual(df_complex.at[3, "dur"], 6)
+        self.assertEqual(df_complex.at[4, "dur"], 5)
+
+    def test_trim_trace_events_different_threads(self):
+        # Given
+        df_threads = pd.DataFrame(
+            {
+                "index": [0, 1, 2, 3],
+                "ts": [0, 2, 4, 6],
+                "dur": [10, 6, 8, 2],
+                "pid": [1, 1, 1, 1],
+                "tid": [1, 1, 2, 2],  # Events 2 and 3 are in a different thread
+                "stream": [-1, -1, -1, -1],
+                "index_correlation": [-1, -1, -1, -1],
+                "python_id": [100, 101, 102, 103],
+                "python_parent_id": [-1, 100, 101, 102],
+                "name": [0, 0, 0, 0],
+            }
+        )
+
+        trace_threads = type(self.trace_mock)({0: df_threads})
+
+        # When
+        CallGraph(trace_threads, pre_process_trace_data=True)
+
+        # Then
+        # Event 2 should not be trimmed because it's in a different thread than its parent
+        self.assertEqual(df_threads.at[2, "dur"], 8)
+
+    def test_trim_trace_events_no_trimming_needed(self):
+        # Given
+        df_no_trim = pd.DataFrame(
+            {
+                "index": [0, 1, 2, 3],
+                "ts": [0, 2, 4, 6],
+                "dur": [10, 6, 3, 1],  # All child events end before their parents
+                "pid": [1, 1, 1, 1],
+                "tid": [1, 1, 1, 1],
+                "stream": [-1, -1, -1, -1],
+                "index_correlation": [-1, -1, -1, -1],
+                "python_id": [100, 101, 102, 103],
+                "python_parent_id": [-1, 100, 101, 102],
+                "name": [0, 0, 0, 0],
+            }
+        )
+
+        trace_no_trim = type(self.trace_mock)({0: df_no_trim})
+
+        # When
+        CallGraph(trace_no_trim, pre_process_trace_data=True)
+
+        # Then
+        # Durations should remain unchanged
+        self.assertEqual(df_no_trim.at[1, "dur"], 6)
+        self.assertEqual(df_no_trim.at[2, "dur"], 3)
+        self.assertEqual(df_no_trim.at[3, "dur"], 1)
+
+    def test_trim_trace_events_multiple_children(self):
+        # Given
+        df_multi_children = pd.DataFrame(
+            {
+                "index": [0, 1, 2, 3, 4],
+                "ts": [0, 2, 3, 6, 8],
+                "dur": [
+                    10,
+                    8,
+                    3,
+                    2,
+                    5,
+                ],  # Child event 4 exceeds parent event 1's duration
+                "pid": [1, 1, 1, 1, 1],
+                "tid": [1, 1, 1, 1, 1],
+                "stream": [-1, -1, -1, -1, -1],
+                "index_correlation": [-1, -1, -1, -1, -1],
+                "python_id": [100, 101, 102, 103, 104],
+                "python_parent_id": [-1, 100, 101, 101, 101],
+                "name": [0, 0, 0, 0, 0],
+            }
+        )
+
+        trace_multi = type(self.trace_mock)({0: df_multi_children})
+
+        # When
+        CallGraph(trace_multi, pre_process_trace_data=True)
+
+        # Then
+        # Event 1: ts=2, dur=8, end=10
+        # Event 4: ts=8, dur=5, should be trimmed to dur=2 to end at 10
+        self.assertEqual(df_multi_children.at[4, "dur"], 2)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
Summary:
### What?

This commit improves CallStackGraph lib in HTA package to handle edge case from Kineto trace data: In traces with Python call stack info, when child Python function doesn't end before parent, it disturbs the assumed time order of events which is very important when constructing call stack graph. Because we know a child function cannot end after its parent, if it is found in the trace it is basically wrong information and we can preprocess the data by truncating the event duration. We can rely on Python event argument "Python id" and "Python parent id" to detect parent-child, then it is just a BFS tree traversal, and for each child, make sure its end time doesn't exceed its parent.

### Why?

Incorrect call stack tree structure impacts the consumers of CallStackGraph, for example accuracy of Python overhead detection, because it depends on the leaf event interval. We have seen a few traces with unexpected high overhead that turned out incorrect. The CPA (Critical Path Analysis) also depends on CallStackGraph.

### How?

1. First we need to add "Python id" and "Python parent id" into the trace DataFrame.
1. Then we introduce a boolean flag "preprocess_trace_data", if true then we run the truncating algorithm before constructing CallStackGraph.
1. The algorithm is just BFS, first scan the DataFrame to create parent child edges, then BFS and truncate each child event's duration if needed.  Note if a parent function invokes a child in different thread, child's duration doesn't need to be truncated so it is treated as a root event.

Differential Revision: D78468146


