### PR TITLE
Upgrade to python 3.12 in pre-commit test.

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # make sure python versions are consistent with those used in .circleci/config.yml
-        python-version: ['3.8.12', '3.9.13', '3.10.4']
+        # make sure python versions are consistent with those used in .github/workflows/ci.yml
+        python-version: ['3.10.0', '3.12.0']
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3


### PR DESCRIPTION
Summary:
Pre-commit is currently running python version 3.0, which doesn't include some of the latest python syntax.

Currently failing with: 

```
hta/common/call_stack.py:504: error: X | Y syntax for unions requires Python
3.10  [syntax]
            remapped_tids: Dict[int, Dict[int, int]] | None = None,
```

Differential Revision: D78677575


