### PR TITLE
Refactor: Convert string queries to df masks

### DIFF
--- a/hta/analyzers/trace_counters.py
+++ b/hta/analyzers/trace_counters.py
@@ -49,9 +49,9 @@ class TraceCounters:
 
         # CUDA Runtime events that may launch kernels
         # - filter events that have a correlated kernel event only.
-        runtime_calls: pd.DataFrame = trace_df.query(
-            t.symbol_table.get_runtime_launch_events_query()
-        ).copy()
+        runtime_calls: pd.DataFrame = trace_df[
+            t.symbol_table.get_runtime_launch_events_mask(trace_df)
+        ].copy()
         runtime_calls.drop(["stream", "pid", "tid"], axis=1, inplace=True)
         runtime_calls["queue"] = 1
 

--- a/hta/common/trace_symbol_table.py
+++ b/hta/common/trace_symbol_table.py
@@ -305,16 +305,20 @@ class TraceSymbolTable:
     # Use a number lower than -1 as a sentinel for missing symbols
     NULL: int = -128
 
-    def get_operator_or_cuda_runtime_query(self) -> str:
-        """Returns a SQL query you can pass to trace dataframe query()
+    def get_operator_or_cuda_runtime_mask(self, df: pd.DataFrame) -> pd.Series:
+        """Returns a boolean mask you can use with pandas dataframes
         to filter events that are CUDA runtime events or operators."""
         cpu_op_id = self.sym_index.get("cpu_op")
         cuda_runtime_id = self.sym_index.get("cuda_driver", self.NULL)
         cuda_driver_id = self.sym_index.get("cuda_runtime", self.NULL)
-        return f"(cat == {cpu_op_id} or cat == {cuda_runtime_id} or cat == {cuda_driver_id})"
+        return (
+            (df["cat"] == cpu_op_id)
+            | (df["cat"] == cuda_runtime_id)
+            | (df["cat"] == cuda_driver_id)
+        )
 
-    def get_runtime_launch_events_query(self) -> str:
-        """Returns a SQL query you can pass to trace dataframe query()
+    def get_runtime_launch_events_mask(self, df: pd.DataFrame) -> pd.Series:
+        """Returns a boolean mask you can use with pandas dataframes
         to filter events that are CUDA runtime kernel and memcpy launches."""
         cudaLaunchKernel_id = self.sym_index.get("cudaLaunchKernel", self.NULL)
         cudaLaunchKernelExC_id = self.sym_index.get("cudaLaunchKernelExC", self.NULL)
@@ -332,15 +336,25 @@ class TraceSymbolTable:
         rocmMemsetAsync_id = self.sym_index.get("hipMemsetAsync", self.NULL)
         rocmMemcpyAsync_id = self.sym_index.get("hipMemcpyAsync", self.NULL)
         rocmMemcpyWithStream_id = self.sym_index.get("hipMemcpyWithStream", self.NULL)
-        return (
-            f"((name == {cudaMemsetAsync_id}) or (name == {cudaMemcpyAsync_id}) or "
-            f"(name == {cudaLaunchKernel_id}) or (name == {cudaLaunchKernelExC_id}) or "
-            f"(name == {cuLaunchKernel_id}) or (name == {mtiaLaunchKernel_id}) or "
-            f"(name == {rocmLaunchKernel_id}) or (name == {rocmExtModuleLaunchKernel_id}) or "
-            f"(name == {rocmMemcpyAsync_id}) or (name == {rocmMemsetAsync_id}) or "
-            f"(name == {rocmMemcpyWithStream_id}) or (name == {cuLaunchKernelEx_id})) "
-            "and (index_correlation > 0)"
+
+        # Create a mask for each event type and combine with OR
+        name_mask = (
+            (df["name"] == cudaMemsetAsync_id)
+            | (df["name"] == cudaMemcpyAsync_id)
+            | (df["name"] == cudaLaunchKernel_id)
+            | (df["name"] == cudaLaunchKernelExC_id)
+            | (df["name"] == cuLaunchKernel_id)
+            | (df["name"] == mtiaLaunchKernel_id)
+            | (df["name"] == rocmLaunchKernel_id)
+            | (df["name"] == rocmExtModuleLaunchKernel_id)
+            | (df["name"] == rocmMemcpyAsync_id)
+            | (df["name"] == rocmMemsetAsync_id)
+            | (df["name"] == rocmMemcpyWithStream_id)
+            | (df["name"] == cuLaunchKernelEx_id)
         )
+
+        # Add the index_correlation > 0 condition
+        return name_mask & (df["index_correlation"] > 0)
 
     def get_cpu_event_cat_ids(self) -> List[int]:
         return list(self.get_symbol_ids(CPU_EVENTS_CATEGORY_PATTERN).values())


### PR DESCRIPTION
Summary:
Refactor string queries to DF masks.

dataframe.query operations (i.e., string queries) are evaluated in NumPy using the NumExpr evaluator. NumExpr is optimized for efficiency, but it has limits on how complex expressions can be. When I attempted to modify the "get_events" query to additional include data_loader events, NumExpr started crashing.

DevMate recommended switching to a boolean mask solution, giving the following reasoning:
1.  **Direct Operations**: Boolean operations are performed directly on the dataframe columns without string parsing
2.  **Better Performance**: Boolean masks are generally faster than query strings for complex conditions
3.  **More Reliable**: No risk of syntax errors in query strings
4.  **Memory Efficient**: Avoids NumExpr's memory overhead for parsing complex expressions
5.  **Easier Debugging**: You can inspect each mask separately to identify issues

Reviewed By: seansundor

Differential Revision: D78381328


