### PR TITLE
Support data loading operations.

### DIFF
--- a/hta/common/trace_symbol_table.py
+++ b/hta/common/trace_symbol_table.py
@@ -356,6 +356,14 @@ class TraceSymbolTable:
         # Add the index_correlation > 0 condition
         return name_mask & (df["index_correlation"] > 0)
 
+    def get_events_mask(self, df: pd.DataFrame, events: list[str] | None) -> pd.Series:
+        """Returns a boolean mask you can use with pandas dataframes
+        to filter for events that are in the given events list (regex supported)."""
+        if events is None:
+            return pd.Series(False, index=df.index)
+        event_ids = self.find_matches(events)
+        return df["name"].isin(event_ids)
+
     def get_cpu_event_cat_ids(self) -> List[int]:
         return list(self.get_symbol_ids(CPU_EVENTS_CATEGORY_PATTERN).values())
 

--- a/hta/trace_analysis.py
+++ b/hta/trace_analysis.py
@@ -675,6 +675,7 @@ class TraceAnalysis:
         rank: int,
         annotation: str,
         instance_id: Union[Optional[int], Tuple[int, int]],
+        data_load_events: Optional[List[str]] = None,
     ) -> Tuple[CPGraph, bool]:
         r"""
         Perform critical path analysis for trace events within a rank.
@@ -697,6 +698,10 @@ class TraceAnalysis:
                         Defaults to the first instance.
                 (Tuple(int, int)) - considers a range of annotation instances start to end,
                         inclusive of both start and end instance.
+            data_load_events (List[str]): List of events (regex) to be considered as
+                data load events. Different traces may use different annotations to
+                indicate data loading, so we allow the caller to pass in the list.
+
         Returns:
             Tuple[CPGraph, bool]
                 A tuple of CPGraph object and a success or fail boolean value.
@@ -715,7 +720,7 @@ class TraceAnalysis:
            Please see the documentation of this PR on how to enable CUDA sync events in the trace.
         """
         return CriticalPathAnalysis.critical_path_analysis(
-            self.t, rank, annotation, instance_id
+            self.t, rank, annotation, instance_id, data_load_events=data_load_events
         )
 
     def overlay_critical_path_analysis(

--- a/tests/test_critical_path_analysis.py
+++ b/tests/test_critical_path_analysis.py
@@ -676,7 +676,10 @@ class EndToEndTestCase(unittest.TestCase):
             )
             rank = 0
             cp_graph, success = critical_path_t.critical_path_analysis(
-                rank=rank, annotation="", instance_id=0
+                rank=rank,
+                annotation="",
+                instance_id=0,
+                data_load_events=["data_load"],
             )
             self.assertTrue(success)
             with TemporaryDirectory(dir="/tmp") as tmpdir:


### PR DESCRIPTION
Summary:
Supports including data loading events on the critical path. In the open-source library, we allow passing in a list of regexes to consider as data loading. For our internal use case, we pass in ["data_loading" and "copy_batch_to_gpu"].

These are both user annotations, so previously they were completely omitted from the critical path. But we've seen that often there are no specific cpu or gpu ops nested inside, and that these are actually the best leaf operators to use.

Note: I'll follow up this diff with another one that adds a new "data loading" category in the CPA breakdown.

Reviewed By: seansundor

Differential Revision: D78374879
