### PR TITLE
Remove | None syntax, as some clients may not be on python 3.1+

### DIFF
--- a/hta/analyzers/critical_path_analysis.py
+++ b/hta/analyzers/critical_path_analysis.py
@@ -602,7 +602,7 @@ class CPGraph(nx.DiGraph):
                         self._add_edge_helper(
                             previous_node, node, CPEdgeType.DEPENDENCY
                         )
-                if not last_node.is_start:
+                if last_node and not last_node.is_start:
                     self._add_edge_helper(last_node, node, CPEdgeType.DEPENDENCY)
 
             last_node = node
@@ -632,7 +632,7 @@ class CPGraph(nx.DiGraph):
         for csg in cpu_call_stacks:
             self._construct_graph_from_call_stack(csg)
 
-    def _get_bwd_tid(self, trace_df: pd.DataFrame) -> int | None:
+    def _get_bwd_tid(self, trace_df: pd.DataFrame) -> Optional[int]:
         """Get the thread id for the backward pass, or None is one cannot be identified.
 
         We identify the backward pass as the thread which contains "autograd" events. If
@@ -648,7 +648,7 @@ class CPGraph(nx.DiGraph):
 
         return self._get_tid_for_event(trace_df, "autograd")
 
-    def _get_fwd_tid(self, trace_df: pd.DataFrame) -> int | None:
+    def _get_fwd_tid(self, trace_df: pd.DataFrame) -> Optional[int]:
         """Get the thread id for the forward pass, or None is one cannot be identified.
 
         We identify the forward pass as the thread which contains
@@ -663,7 +663,7 @@ class CPGraph(nx.DiGraph):
         """
         return self._get_tid_for_event(trace_df, "forward")
 
-    def _get_tid_for_event(self, trace_df: pd.DataFrame, ev_name: str) -> int | None:
+    def _get_tid_for_event(self, trace_df: pd.DataFrame, ev_name: str) -> Optional[int]:
         events = [sym for sym in self.symbol_table.sym_table if ev_name in sym]
         event_ids = [self.symbol_table.sym_index[candidate] for candidate in events]
         cpu_op_id = self.symbol_table.sym_index.get("cpu_op", -1)

--- a/hta/common/call_stack.py
+++ b/hta/common/call_stack.py
@@ -461,7 +461,7 @@ class CallGraph:
         trace: Trace,
         ranks: Optional[List[int]] = None,
         filter_func: Optional[Filter] = None,
-        remapped_tids: Dict[int, Dict[int, int]] | None = None,
+        remapped_tids: Optional[Dict[int, Dict[int, int]]] = None,
     ) -> None:
         """Construct a CallGraph from a Trace object <trace_data>
 
@@ -501,7 +501,7 @@ class CallGraph:
         self,
         ranks: List[int],
         filter_func: Optional[Filter],
-        remapped_tids: Dict[int, Dict[int, int]] | None = None,
+        remapped_tids: Optional[Dict[int, Dict[int, int]]] = None,
     ) -> None:
         """
         Construct the call graph from the traces of a distributed training job.


### PR DESCRIPTION
Summary:
Pre-commit is currently running python versions < 3.10, which don't include some of the latest python syntax. So it's failing with this error:

`error: X | Y syntax for unions requires Python 3.10`.

Pre-commit is defined here: https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/.github/workflows/pre-commit.yml

We can probably opt the pre-commit to later python versions, although it's unclear if any clients are still running older python. For now, we'll just use older syntax in our code.

Differential Revision: D78617560


