### PR TITLE
Clamp pandas version to work with newer python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 jupyterlab>=3.5.1
 numpy>=1.23.5
 networkx>=3.1
-pandas>=1.5.2
+pandas>=1.5.2,<3.0.0
 plotly>=5.11.0
 pydot>=1.3.0  # required by third_party/param/
 pytest>=7.4.4


### PR DESCRIPTION
## What does this PR do?
Partially fixes https://github.com/facebookresearch/HolisticTraceAnalysis/issues/318. As the issue suggests clamps down pandas version to `<3.0.0`

## Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [x] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [x] N/A
