### PR TITLE
Fix numpy compat issue with np.unique on object dtype arrays (#328)

### DIFF
--- a/hta/common/trace_call_stack.py
+++ b/hta/common/trace_call_stack.py
@@ -356,6 +356,7 @@ class CallStackGraph:
                 value_name="time",
             )
             .replace({"ts": -1, "end": 1})
+            .assign(kind=lambda x: x["kind"].astype(int))
             .sort_values("time")
         ).to_numpy()
 

--- a/hta/configs/parser_config.py
+++ b/hta/configs/parser_config.py
@@ -1,4 +1,5 @@
 # pyre-strict
+from __future__ import annotations
 
 import copy
 import re

--- a/tests/test_call_stack.py
+++ b/tests/test_call_stack.py
@@ -5,6 +5,7 @@
 
 import unittest
 
+import numpy as np
 import pandas as pd
 from hta.common.call_stack import (
     CallGraph,
@@ -137,6 +138,28 @@ class CallStackTestCase(unittest.TestCase):
         self.assertDictEqual(depth_from_csg, depth_from_nodes)
         # Verify df is used
         self.assertIsNotNone(df)
+
+    def test_events_array_numeric_dtype(self):
+        """astype(int) ensures kind column is numeric for np.unique(axis=0)."""
+        df = pd.DataFrame(
+            {"index": [0, 1], "ts": [100, 200], "dur": [10, 20], "stream": [-1, -1]}
+        )
+        df["end"] = df["ts"] + df["dur"]
+        events = (
+            df.melt(
+                id_vars=["index", "dur"],
+                value_vars=["ts", "end"],
+                var_name="kind",
+                value_name="time",
+            )
+            .replace({"ts": -1, "end": 1})
+            .assign(kind=lambda x: x["kind"].astype(int))
+            .to_numpy()
+        )
+        # kind column must be numeric, not object, for np.unique(axis=0)
+        # to work on newer numpy versions.
+        self.assertTrue(events.dtype.kind in ("i", "f"))  # int or float
+        self.assertIsNotNone(np.unique(events, axis=0))
 
 
 class CallGraphTestCase(unittest.TestCase):


### PR DESCRIPTION
Summary:

`np.unique(events, axis=0)` in `trace_call_stack.py:367` fails on newer numpy
versions when the `events` array has `dtype object`.

**Root cause**: DataFrame.replace({"ts": -1, "end": 1}) converts the kind
column values from strings ("ts", "end") to ints (-1, 1), but on newer
pandas versions the column dtype remains object instead of being inferred
as int64. When to_numpy() creates the array, the object dtype causes
np.unique(axis=0) to throw TypeError.

Fix: add `.assign(kind=lambda x: x["kind"].astype(int))` to the chain,
forcing `kind` to int dtype before `to_numpy()`.

This fixes the OSS CI failures:
- [facebookresearch/HolisticTraceAnalysis: CI / build (3.10)](https://github.com/facebookresearch/HolisticTraceAnalysis/actions/runs/23827081316/job/69452407257?pr=324)

Differential Revision: D99093340
