### PR TITLE
Fix pandas 3.0 and numpy 2.x compatibility for GitHub CI (#330)

### DIFF
--- a/hta/analyzers/breakdown_analysis.py
+++ b/hta/analyzers/breakdown_analysis.py
@@ -889,7 +889,7 @@ class BreakdownAnalysis:
             member.value: name.lower()
             for name, member in IdleTimeType.__members__.items()
         }
-        result_df.rename(mapper=idle_category_name_map, axis=0, inplace=True)
+        result_df.rename(index=idle_category_name_map, inplace=True)
         result_df.reset_index(inplace=True)
 
         if visualize:  # pragma: no cover
@@ -924,9 +924,7 @@ class BreakdownAnalysis:
         if interval_stats_df is not None:
             # add rank column to the starting
             interval_stats_df.insert(0, "rank", rank)
-            interval_stats_df.rename(
-                mapper=idle_category_name_map, axis=0, inplace=True
-            )
+            interval_stats_df.rename(index=idle_category_name_map, inplace=True)
 
         result_df = result_df[
             ["rank", "stream", "idle_category", "idle_time", "idle_time_ratio"]

--- a/hta/analyzers/critical_path_analysis.py
+++ b/hta/analyzers/critical_path_analysis.py
@@ -473,17 +473,17 @@ class CPGraph(nx.DiGraph):
         ops_df_start = events_df.copy()
         ops_df_end = events_df.copy()
 
-        ops_df_start.drop(axis=1, columns=["dur"], inplace=True)
+        ops_df_start.drop(columns=["dur"], inplace=True)
         ops_df_start["is_start"] = True
 
         ops_df_end["end"] = ops_df_end["ts"] + ops_df_end["dur"]
-        ops_df_end.drop(axis=1, columns=["dur", "ts"], inplace=True)
+        ops_df_end.drop(columns=["dur", "ts"], inplace=True)
         ops_df_end.rename(columns={"end": "ts"}, inplace=True)
         ops_df_end["is_start"] = False
 
         nodes_df = (
             pd.concat([ops_df_start, ops_df_end])
-            .sort_values(by=["ts", "ev_idx"], axis=0)
+            .sort_values(by=["ts", "ev_idx"])
             .reset_index(drop=True)
             .reset_index(names="idx")
         )
@@ -815,7 +815,7 @@ class CPGraph(nx.DiGraph):
                     self.symbol_table.get_runtime_launch_events_mask(self.full_trace_df)
                 ]
                 .copy()
-                .sort_values(by="ts", axis=0)
+                .sort_values(by="ts")
             )
             .merge(
                 gpu_kernels[["stream", "index", "pid"]],
@@ -894,7 +894,7 @@ class CPGraph(nx.DiGraph):
         cuda_record_calls_ = (
             self.full_trace_df.query(f"name == {cudaEventRecord_id}")
             .copy()
-            .sort_values(by="ts", axis=0)
+            .sort_values(by="ts")
         )
 
         # Each CUDA Event Record has a specific stream, gpu the event was recorded on.
@@ -919,7 +919,7 @@ class CPGraph(nx.DiGraph):
             """Correlates the closes CUDA kernel launch to a CUDA Record Event"""
             comb = (
                 pd.concat([runtime_calls, cuda_record_calls])
-                .sort_values(by="ts", axis=0)
+                .sort_values(by="ts")
                 .query(f"gpu == {gpu} and stream == {stream}")
                 .copy()
             )
@@ -929,7 +929,7 @@ class CPGraph(nx.DiGraph):
 
             comb_launches = comb.loc[comb.name != cudaEventRecord_id].copy()
             comb_cuda_records = comb.loc[comb.name == cudaEventRecord_id].copy()
-            comb_cuda_records.drop(axis=1, columns="launch_id", inplace=True)
+            comb_cuda_records.drop(columns="launch_id", inplace=True)
 
             # Now join the previous_launch_id to actual kernel launch events.
             return pd.merge(
@@ -955,14 +955,11 @@ class CPGraph(nx.DiGraph):
         if len(cuda_record_dfs) == 0:
             return None
 
-        cuda_record_calls = pd.concat(cuda_record_dfs, axis=0).sort_values(
-            by="ts", axis=0
-        )
+        cuda_record_calls = pd.concat(cuda_record_dfs, axis=0).sort_values(by="ts")
 
         # Cleanup temporary columns
         # PS: you can comment the below if you need to debug any issue
         cuda_record_calls.drop(
-            axis=1,
             columns=["launch_id", "previous_launch_id"],
             inplace=True,
         )
@@ -992,7 +989,7 @@ class CPGraph(nx.DiGraph):
 
         # CUDA launch runtime calls
         runtime_calls = self._get_cuda_runtime_calls_df()
-        runtime_calls.drop(axis=1, columns=["stream"], inplace=True)
+        runtime_calls.drop(columns=["stream"], inplace=True)
         runtime_calls.rename(columns={"stream_kernel": "stream"}, inplace=True)
 
         gpu_kernels = self.full_trace_df.query("stream != -1 and index_correlation > 0")
@@ -1015,7 +1012,7 @@ class CPGraph(nx.DiGraph):
                     ]
                 ]
                 .copy()
-                .sort_values(by="ts", axis=0)
+                .sort_values(by="ts")
             )
             .merge(
                 gpu_kernels[["stream", "index"]],
@@ -1032,7 +1029,7 @@ class CPGraph(nx.DiGraph):
             # on the same pid, tid, stream
             comb = (
                 pd.concat([runtime_calls, cuda_stream_wait_events])
-                .sort_values(by="ts", axis=0)
+                .sort_values(by="ts")
                 .query(f"pid == {pid} and tid == {tid} and stream == {stream}")
                 .copy()
             )
@@ -1046,7 +1043,7 @@ class CPGraph(nx.DiGraph):
             comb_stream_wait_events = comb.loc[
                 comb.name == cudaStreamWaitEvent_id
             ].copy()
-            comb_stream_wait_events.drop(axis=1, columns="launch_id", inplace=True)
+            comb_stream_wait_events.drop(columns="launch_id", inplace=True)
 
             # Now join the next_launch_id to actual kernel launch events.
             return pd.merge(
@@ -1070,11 +1067,10 @@ class CPGraph(nx.DiGraph):
                 for r in pid_tid_streams
             ],
             axis=0,
-        ).sort_values(by="ts", axis=0)
+        ).sort_values(by="ts")
 
         # Cleanup temporary columns
         cuda_stream_wait_events.drop(
-            axis=1,
             columns=["launch_id", "next_launch_id", "correlation_launch_event"],
             inplace=True,
         )
@@ -1175,14 +1171,18 @@ class CPGraph(nx.DiGraph):
         ):
             # Join the event sync event with the index of the kernel/memcpy launch
             # that is was syncing on.
-            gpu_kernels = pd.merge(
-                gpu_kernels,
-                cuda_record_calls[["correlation", "index_previous_launch"]],
-                left_on="wait_on_cuda_event_record_corr_id",
-                right_on="correlation",
-                how="left",
-                suffixes=("", "_cuda_record"),
-            ).fillna(-1)
+            gpu_kernels = (
+                pd.merge(
+                    gpu_kernels,
+                    cuda_record_calls[["correlation", "index_previous_launch"]],
+                    left_on="wait_on_cuda_event_record_corr_id",
+                    right_on="correlation",
+                    how="left",
+                    suffixes=("", "_cuda_record"),
+                )
+                .fillna({"index_previous_launch": -1, "correlation_cuda_record": -1})
+                .astype({"index_previous_launch": int, "correlation_cuda_record": int})
+            )
             # Note convert NAN to -1 and then turn all records to int
 
         # Sort kernels by start timestamp but use end time_stamp for sync events.
@@ -1195,7 +1195,7 @@ class CPGraph(nx.DiGraph):
         gpu_kernels.loc[gpu_kernels.cat == sync_cat, "sort_by"] = gpu_kernels[
             gpu_kernels.cat == sync_cat
         ]["end_ts"]
-        gpu_kernels.sort_values(by="sort_by", axis=0, inplace=True)
+        gpu_kernels.sort_values(by="sort_by", inplace=True)
 
         # Last node on a stream
         last_node: Dict[int, CPNode] = {}

--- a/hta/analyzers/cuda_kernel_analysis.py
+++ b/hta/analyzers/cuda_kernel_analysis.py
@@ -220,7 +220,7 @@ class CudaKernelAnalysis:
             )
             fig.update_xaxes(type="category")
             fig.show()
-        return patterns_df.drop("pattern_indices", axis=1)
+        return patterns_df.drop(columns="pattern_indices")
 
     @classmethod
     def _overlay_frequent_patterns_with_trace(
@@ -244,7 +244,7 @@ class CudaKernelAnalysis:
         """
         raw_trace_content = t.get_raw_trace_for_one_rank(rank=rank)
         raw_trace_df = pd.DataFrame(raw_trace_content["traceEvents"]).reset_index()
-        raw_trace_df["index"] = pd.to_numeric(raw_trace_df["index"], downcast="integer")
+        raw_trace_df["index"] = pd.to_numeric(raw_trace_df["index"])
         sym_id_map: Dict[str, int] = t.symbol_table.get_sym_id_map()
 
         # get a counter of patterns that each CPU operator/GPU kernel is in.
@@ -264,7 +264,7 @@ class CudaKernelAnalysis:
         )
         # ensure the index column to be removed for merging with the original events
         if "index" in top_patterns_df.columns:
-            top_patterns_df.drop(["index"], axis=1, inplace=True)
+            top_patterns_df.drop(columns=["index"], inplace=True)
 
         # join the pattern counter with the original events on their indices
         merged_df = raw_trace_df.merge(
@@ -309,7 +309,7 @@ class CudaKernelAnalysis:
             ]
         # drop unused columns before writing back to the overlaid trace file
         merged_df.drop(
-            ["index", "active_patterns", "pattern_indices"], axis=1, inplace=True
+            columns=["index", "active_patterns", "pattern_indices"], inplace=True
         )
         raw_trace_content["traceEvents"] = list(
             merged_df.apply(lambda row: row.dropna().to_dict(), axis=1)

--- a/hta/analyzers/straggler.py
+++ b/hta/analyzers/straggler.py
@@ -46,7 +46,7 @@ def extract_iteration_info(trace: Trace) -> pd.DataFrame:
         p_steps["iter"] = p_steps["profiler_step"].apply(get_iter_nbr)
         p_steps["end"] = p_steps["ts"] + p_steps["dur"]
         p_steps.set_index("iter", inplace=True)
-        p_steps.drop(["profiler_step"], axis=1, inplace=True)
+        p_steps.drop(columns=["profiler_step"], inplace=True)
         return p_steps
 
     df_iterations = pd.concat(

--- a/hta/analyzers/trace_counters.py
+++ b/hta/analyzers/trace_counters.py
@@ -51,7 +51,7 @@ class TraceCounters:
         runtime_calls: pd.DataFrame = trace_df[
             t.symbol_table.get_runtime_launch_events_mask(trace_df)
         ].copy()
-        runtime_calls.drop(["stream", "pid", "tid"], axis=1, inplace=True)
+        runtime_calls.drop(columns=["stream", "pid", "tid"], inplace=True)
         runtime_calls["queue"] = 1
 
         # GPU kernel events

--- a/hta/common/timeline.py
+++ b/hta/common/timeline.py
@@ -182,7 +182,7 @@ def _set_task_names(events: pd.DataFrame, setting: TimelinePlotSetting) -> pd.Se
     def _compute_label_col(prefix: str, col: pd.Series) -> pd.Series:
         return pd.Series(
             f"{prefix} " + col.str.pad(width=5, side="right")
-            if col.dtype == object
+            if pd.api.types.is_string_dtype(col)
             else f"{prefix} " + col.astype(str).str.zfill(3)
         )
 
@@ -289,14 +289,22 @@ def align_module_with_kernels(
     cpu_events = events_df.loc[
         events_df["stream"].eq(CPUStreamID) & events_df["num_kernels"].ge(1)
     ]
-    if sym_table and "name" in events_df.columns and events_df["name"].dtype != object:
+    if (
+        sym_table
+        and "name" in events_df.columns
+        and not pd.api.types.is_string_dtype(events_df["name"])
+    ):
         indices_to_annotate = find_events_by_name_patterns_using_symbol_table(
             cpu_events, module_list, sym_table
         )
     else:
-        if "name" in events_df.columns and events_df["name"].dtype == object:
+        if "name" in events_df.columns and pd.api.types.is_string_dtype(
+            events_df["name"]
+        ):
             column = "name"
-        elif "s_name" in events_df.columns and events_df["s_name"].dtype == object:
+        elif "s_name" in events_df.columns and pd.api.types.is_string_dtype(
+            events_df["s_name"]
+        ):
             column = "s_name"
         else:
             error_msg = (

--- a/hta/common/trace.py
+++ b/hta/common/trace.py
@@ -126,7 +126,9 @@ def transform_correlation_to_index(
     merged = on_cpu.merge(on_gpu, on="correlation", how="inner")
     df.loc[merged["index_x"], "index_correlation"] = merged["index_y"].values
     df.loc[merged["index_y"], "index_correlation"] = merged["index_x"].values
-    df["index_correlation"] = pd.to_numeric(df["index_correlation"], downcast="integer")
+    df["index_correlation"] = (
+        pd.to_numeric(df["index_correlation"]).fillna(-1).astype(int)
+    )
     return df
 
 
@@ -221,7 +223,7 @@ def add_iteration(df: pd.DataFrame, symbol_table: TraceSymbolTable) -> pd.DataFr
     df.loc[df["stream"].gt(0), "iteration"] = df["index_correlation"].apply(
         lambda x: df.loc[x, "iteration"] if x > 0 else -1
     )
-    df["iteration"] = pd.to_numeric(df["iteration"], downcast="integer")
+    df["iteration"] = pd.to_numeric(df["iteration"]).fillna(-1).astype(int)
 
     return profiler_steps
 

--- a/hta/common/trace_call_graph.py
+++ b/hta/common/trace_call_graph.py
@@ -256,7 +256,7 @@ class CallGraph:
             df.loc[indices_no_kernel_child, "last_kernel_end"] = -1
 
             for col in ["depth", "height", "parent", "num_kernels"]:
-                df[col] = pd.to_numeric(df[col], errors="coerce", downcast="integer")
+                df[col] = pd.to_numeric(df[col], errors="coerce")
 
     def _connect_stacks(self, rank: int) -> None:
         """Connect the CallStackGraph of the main threads and the backward threads."""

--- a/hta/common/trace_call_stack.py
+++ b/hta/common/trace_call_stack.py
@@ -356,6 +356,7 @@ class CallStackGraph:
                 value_name="time",
             )
             .replace({"ts": -1, "end": 1})
+            .assign(kind=lambda x: x["kind"].astype(int))
             .sort_values("time")
         ).to_numpy()
 

--- a/hta/common/trace_filter.py
+++ b/hta/common/trace_filter.py
@@ -226,7 +226,8 @@ class NameStringColumnFilter(Filter):
     ) -> pd.DataFrame:
         name_column, _ = get_symbol_column_names(df)
         if name_column == "" or (
-            name_column in df.columns and df[name_column].dtype != object
+            name_column in df.columns
+            and not pd.api.types.is_string_dtype(df[name_column])
         ):
             logger.warning("The DataFrame doesn't have a name column of string type")
             return df

--- a/hta/common/trace_parser.py
+++ b/hta/common/trace_parser.py
@@ -294,7 +294,7 @@ def _compress_df(
 
     # drop columns
     columns_to_drop = {"ph", "id", "bp", "s"}.intersection(set(df.columns))
-    df.drop(list(columns_to_drop), axis=1, inplace=True)
+    df.drop(columns=list(columns_to_drop), inplace=True)
     columns = set(df.columns)
 
     # performance counters appear as args
@@ -334,7 +334,7 @@ def _compress_df(
                     else arg.default_value
                 )
             )
-        df.drop(["args"], axis=1, inplace=True)
+        df.drop(columns=["args"], inplace=True)
 
     normalize_gpu_stream_numbers(df)
 
@@ -347,10 +347,10 @@ def _compress_df(
     for col in ["cat", "name"]:
         df[col] = df[col].apply(lambda s: sym_index[s])
 
-    # data type downcast
+    # data type downcast (downcast removed in pandas 3.0, keep as int64)
     for col in df.columns:
         if df[col].dtype.kind == "i":
-            df[col] = pd.to_numeric(df[col], errors="coerce", downcast="integer")
+            df[col] = pd.to_numeric(df[col], errors="coerce")
 
     return df, local_symbol_table
 
@@ -398,7 +398,7 @@ def _parse_trace_dataframe_json(
 
         # assign an index to each event
         df.reset_index(inplace=True)
-        df["index"] = pd.to_numeric(df["index"], downcast="integer")
+        df["index"] = pd.to_numeric(df["index"])
 
         df, local_symbol_table = _compress_df(df, cfg)
 
@@ -446,7 +446,7 @@ def _parse_trace_dataframe_ijson(
 
     # assign an index to each event
     df.reset_index(inplace=True)
-    df["index"] = pd.to_numeric(df["index"], downcast="integer")
+    df["index"] = pd.to_numeric(df["index"])
 
     df, local_symbol_table = _compress_df(df, cfg)
     return meta, df, local_symbol_table

--- a/hta/common/trace_stack_filter.py
+++ b/hta/common/trace_stack_filter.py
@@ -92,8 +92,8 @@ class OperatorFilter(Filter):
         if (
             name_column not in df.columns
             or cat_column not in df.columns
-            or df.dtypes[name_column] != "object"
-            or df.dtypes[cat_column] != "object"
+            or not pd.api.types.is_string_dtype(df[name_column])
+            or not pd.api.types.is_string_dtype(df[cat_column])
         ):
             logger.error(f"df has no string column {name_column} of {cat_column}")
             return df

--- a/hta/common/trace_symbol_table.py
+++ b/hta/common/trace_symbol_table.py
@@ -239,9 +239,9 @@ class TraceSymbolTable:
         """
         if (
             ("name" in df.columns)
-            and (df["name"].dtype.kind == "O")
+            and (pd.api.types.is_string_dtype(df["name"]))
             and ("cat" in df.columns)
-            and (df["cat"].dtype == "O")
+            and (pd.api.types.is_string_dtype(df["cat"]))
         ):
             symbols = set(df["cat"].unique()).union(set(df["name"].unique()))
             symbol_table = TraceSymbolTable()
@@ -268,7 +268,7 @@ class TraceSymbolTable:
     def encode_df(self, df: pd.DataFrame) -> None:
         """Encode the name and cat columns of a DataFrame with this symbol table."""
         for col in ["name", "cat"]:
-            if col in df.columns and df[col].dtype.kind == "O":
+            if col in df.columns and pd.api.types.is_string_dtype(df[col]):
                 df[col] = df[col].apply(lambda sym: self.sym_index[sym])
 
     def decode_df(self, df: pd.DataFrame, create_new_columns: bool = True) -> None:

--- a/hta/configs/parser_config.py
+++ b/hta/configs/parser_config.py
@@ -1,4 +1,5 @@
 # pyre-strict
+from __future__ import annotations
 
 import copy
 import re

--- a/hta/utils/utils.py
+++ b/hta/utils/utils.py
@@ -133,7 +133,7 @@ def merge_kernel_intervals(kernel_df: pd.DataFrame) -> pd.DataFrame:
     kernel_df = (
         kernel_df.groupby("group", as_index=False)
         .agg({"ts": "min", "end": "max"})
-        .drop(["group"], axis=1)
+        .drop(columns=["group"])
         .sort_values(by="ts")
     )
     return kernel_df
@@ -209,11 +209,11 @@ def get_symbol_column_names(df: pd.DataFrame) -> Tuple[str, str]:
     """
     name_column, cat_column = "", ""
     for column_name in ["name", "s_name"]:
-        if column_name in df.columns and df.dtypes[column_name] == "object":
+        if column_name in df.columns and pd.api.types.is_string_dtype(df[column_name]):
             name_column = column_name
             break
     for column_name in ["cat", "s_cat"]:
-        if column_name in df.columns and df.dtypes[column_name] == "object":
+        if column_name in df.columns and pd.api.types.is_string_dtype(df[column_name]):
             cat_column = column_name
             break
     return name_column, cat_column

--- a/tests/test_call_stack.py
+++ b/tests/test_call_stack.py
@@ -5,6 +5,7 @@
 
 import unittest
 
+import numpy as np
 import pandas as pd
 from hta.common.call_stack import (
     CallGraph,
@@ -137,6 +138,28 @@ class CallStackTestCase(unittest.TestCase):
         self.assertDictEqual(depth_from_csg, depth_from_nodes)
         # Verify df is used
         self.assertIsNotNone(df)
+
+    def test_events_array_numeric_dtype(self):
+        """astype(int) ensures kind column is numeric for np.unique(axis=0)."""
+        df = pd.DataFrame(
+            {"index": [0, 1], "ts": [100, 200], "dur": [10, 20], "stream": [-1, -1]}
+        )
+        df["end"] = df["ts"] + df["dur"]
+        events = (
+            df.melt(
+                id_vars=["index", "dur"],
+                value_vars=["ts", "end"],
+                var_name="kind",
+                value_name="time",
+            )
+            .replace({"ts": -1, "end": 1})
+            .assign(kind=lambda x: x["kind"].astype(int))
+            .to_numpy()
+        )
+        # kind column must be numeric, not object, for np.unique(axis=0)
+        # to work on newer numpy versions.
+        self.assertTrue(events.dtype.kind in ("i", "f"))  # int or float
+        self.assertIsNotNone(np.unique(events, axis=0))
 
 
 class CallGraphTestCase(unittest.TestCase):

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -87,11 +87,19 @@ class TestTimelineAnalysis(unittest.TestCase):
         plot_setting = TimelinePlotSetting(task_height=50, plot_format=PlotFormat.File)
 
         mock_figure = Mock()
-        mock_figure.show.side_effects = [None for i in range(len(test_cases))]
-        mock_figure.update_layout.side_effects = [None for i in range(len(test_cases))]
-        mock_figure.write_html.side_effects = [None for i in range(len(test_cases))]
-        mock_figure.write_image.side_effects = [None for i in range(len(test_cases))]
-        mock_figure.data = [Mock(x=i, name=str(i)) for i in range(10)]
+        mock_figure.show.return_value = None
+        mock_figure.update_layout.return_value = mock_figure
+        mock_figure.write_html.return_value = None
+        mock_figure.write_image.return_value = None
+        mock_figure.layout = Mock()
+        mock_figure.layout.xaxis = Mock()
+        mock_data_items = []
+        for i in range(10):
+            item = Mock()
+            item.name = str(i)
+            item.x = list(range(i))
+            mock_data_items.append(item)
+        mock_figure.data = mock_data_items
         mock_timeline.return_value = mock_figure
 
         for i, tc in enumerate(test_cases):


### PR DESCRIPTION
Summary:

Fixes pre-existing GitHub CI test failures caused by pandas 3.0 and numpy 2.x
breaking changes. The OSS HTA requirements.txt has no upper bounds on
pandas/numpy, so CI picks up latest versions (pandas 3.0.2, numpy 2.4.4).

All changes are backward-compatible with internal Meta versions (pandas 2.0.x,
numpy 1.23.5).

**pandas 3.0 changes:**
- Removed deprecated `axis` parameter from `DataFrame.drop()` -- use
  `columns=` keyword instead (17 call sites across 6 files)
- Removed deprecated `axis` parameter from `DataFrame.rename()` -- use
  `index=` keyword instead (2 call sites)
- Removed deprecated `axis` parameter from `DataFrame.sort_values()` --
  `axis=0` was the default, just drop it (8 call sites)
- String columns now use `StringDtype` instead of `object` dtype -- use
  `pd.api.types.is_string_dtype()` instead of `is_object_dtype()` or
  `dtype == object` for string column detection (9 call sites across 5 files).
  In pandas 2.x, strings were stored as `object` dtype so both functions
  returned True. In pandas 3.0, strings default to `StringDtype`, so
  `is_object_dtype()` returns False for string columns while
  `is_string_dtype()` works correctly on both versions.
- Removed deprecated `downcast="integer"` from `pd.to_numeric()` calls
  (7 call sites across 5 files). This parameter was removed in pandas 3.0.
  Added explicit `.fillna(-1).astype(int)` where needed to preserve integer
  dtype after operations that introduce NaN.
- Fixed `fillna(-1)` after left merge to use column-specific fill with
  explicit `.astype(int)` to prevent float columns.

**numpy 2.x changes:**
- `np.unique(axis=0)` fails on object dtype arrays -- force int dtype with
  `.assign(kind=lambda x: x["kind"].astype(int))` before `to_numpy()`

**Test fixes:**
- `Mock(name="x")` sets internal `_mock_name`, not `.name` attribute --
  use explicit `item.name = str(i)` assignment
- Added `from __future__ import annotations` to `parser_config.py` for
  `tuple[...]` subscript syntax compatibility with mypy

Reference: https://pandas.pydata.org/docs/whatsnew/v3.0.0.html

Differential Revision: D99501369


