### PR TITLE
Add MAX_EVENT_DURATION_US constant and max_event_duration_us to ParserConfig (#331)

### DIFF
--- a/hta/common/constants.py
+++ b/hta/common/constants.py
@@ -2,7 +2,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-strict
+
 # The Max queue size is not really documented and is an implementation detail
 # https://forums.developer.nvidia.com/t/maximum-number-of-operations-in-a-stream/255260
 # We anecdotally see 1022 - 1024 to cause blocking of runtime operations.
 CUDA_MAX_LAUNCH_QUEUE_PER_STREAM: int = 1024
+
+# Max valid trace event duration. Events beyond this are corrupted (CUPTI timestamp overflow).
+MAX_EVENT_DURATION_US: int = 604_800_000_000  # 7 days in microseconds

--- a/hta/configs/parser_config.py
+++ b/hta/configs/parser_config.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import Dict, List, Optional, Set, Union
 
 import pandas as pd
+from hta.common.constants import MAX_EVENT_DURATION_US
 from hta.configs.default_values import AttributeSpec, EventArgs, ValueType
 from hta.configs.event_args_yaml_parser import (
     parse_event_args_yaml,
@@ -113,6 +114,10 @@ class ParserConfig:
         # config to convert ts to nearest integer
         self.convert_ts_to_integer = convert_ts_to_integer
 
+        # Max valid event duration in microseconds. Events exceeding this are
+        # dropped as corrupted (e.g. CUPTI timestamp overflow). Set to None to disable.
+        self.max_event_duration_us: Optional[int] = MAX_EVENT_DURATION_US
+
     def clone(self) -> "ParserConfig":
         return copy.deepcopy(self)
 
@@ -160,6 +165,7 @@ class ParserConfig:
         _DEFAULT_PARSER_CONFIG.set_parse_all_args(cfg.parse_all_args)
         _DEFAULT_PARSER_CONFIG.set_args_selector(cfg.selected_arg_keys)
         _DEFAULT_PARSER_CONFIG.set_skip_event_types(cfg.skip_event_types)
+        _DEFAULT_PARSER_CONFIG.max_event_duration_us = cfg.max_event_duration_us
 
     @classmethod
     def get_minimum_args(

--- a/tests/test_parser_config.py
+++ b/tests/test_parser_config.py
@@ -307,6 +307,19 @@ class ParserConfigTestCase(unittest.TestCase):
         self.assertIn("parser_backend=", repr_str)
         self.assertIn("version=", repr_str)
 
+    def test_default_max_event_duration(self) -> None:
+        """ParserConfig should default max_event_duration_us to 7 days in microseconds."""
+        cfg = ParserConfig()
+        seven_days_us = 7 * 24 * 60 * 60 * 1_000_000
+        self.assertEqual(cfg.max_event_duration_us, seven_days_us)
+
+    def test_set_default_cfg_propagates_max_event_duration(self) -> None:
+        """set_default_cfg should propagate max_event_duration_us to the global default."""
+        custom_cfg = ParserConfig()
+        custom_cfg.max_event_duration_us = 999
+        ParserConfig.set_default_cfg(custom_cfg)
+        self.assertEqual(ParserConfig.get_default_cfg().max_event_duration_us, 999)
+
 
 class TestParseEventArgsYaml(unittest.TestCase):
     @data_provider(


### PR DESCRIPTION
Summary:

**Problem**:
- When triggering HTA via #eiq, the flow failed with error: 'ParserConfig' object has no attribute 'max_event_duration_us'.

**Root Cause:**
- D98705186 (OSS HTA, still "Needs Review") adds MAX_EVENT_DURATION_US to hta.common.constants and self.max_event_duration_us to ParserConfig.
- D98706662 (open HTA) was landed with code that accesses cfg.max_event_duration_us but then reverted because D98705186 hadn't landed yet. The migration commit (b9cea9dd97d9) forgot to sync uncommitted hta.common.constants from OSS HTA.

**Fix:**
- Sync hta.common.constants to open_hta and add max_event_duration_us to ParserConfig
This diff and D99781495 unblock re-landing D98706662 (the duration filtering for corrupted CUPTI timestamps) since the max_event_duration_us attribute now exists on ParserConfig in both codebases.

Reviewed By: CptGit, leitian

Differential Revision: D99781495


