### PR TITLE
Release v0.6.0 — update changelog and add release docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,37 +1,44 @@
 name: CI
 
 on:
-    pull_request:
-    push:
-      branches: ["main"]
+  pull_request:
+  push:
+    branches: ["main"]
 
 env:
+  # Opt in early for Node runtime migration of JS-based actions
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.12"]
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: |
+            requirements.txt
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install -U pip setuptools wheel
           pip install -r requirements.txt
+          pip install pytest pytest-cov
 
       - name: Run tests
         run: |
-          pip install pytest pytest-cov
-          git submodule sync
-          git submodule update --init
-          pytest tests/*.py --doctest-modules --junitxml=junit/test-results.xml --cov-report=xml --cov-report=html
+          pytest tests --doctest-modules \
+            --junitxml=junit/test-results.xml \
+            --cov-report=xml --cov-report=html

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,15 +5,15 @@ on:
   push:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.12']
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.12"
     - uses: pre-commit/action@v3.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,18 +3,43 @@ All notable changes to this project will be documented in this file. The format 
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.0] - Unreleased
+## [0.6.0] - 2026-04-08
+
+#### Added
+- Added `MAX_EVENT_DURATION_US` constant and `max_event_duration_us` to `ParserConfig` to filter corrupted trace events exceeding maximum duration.
+- Added NCCL `seq_num` (sequence number) field mapping to event args config for tracking collective operations.
+- Added NCCL `collective_name` field parsing to identify collective operation types.
+- Added `get_device_type()` method and MTIA trace support including device type inference from trace metadata.
+- Added configurable timestamp integer conversion via parser config.
+- Added `KERNEL_KERNEL_DELAY_THRESHOLD_US` constant to identify unrecognized dependencies in critical path analysis.
+- Added event duration trimming based on tree hierarchy in CallGraph library.
+- Added `pre_grad_nodes` to parser config for inference trace support.
+
 #### Changed
 - Dropped support for Python 3.8 and 3.9 (both EOL). Minimum supported version is now Python 3.10.
 - Added Python 3.12 to supported versions and CI matrix.
 - Updated GitHub Actions to latest versions (checkout@v4, setup-python@v5).
+- Fixed GitHub Actions Node.js 16 deprecation warnings by upgrading to Node 20.
+- Improved CI workflow: added pip caching, switched to `actions/checkout` submodules support, consolidated pip install steps.
 - Aligned pre-commit CI Python versions with main CI workflow (3.10, 3.12).
 - Updated pre-commit hooks: pre-commit-hooks v4.6.0, flake8 7.1.0, mypy v1.11.0.
 - Updated ReadTheDocs build environment to ubuntu-22.04 with Python 3.12.
 - Updated Sphinx documentation dependencies (sphinx>=7.0.0, sphinx_rtd_theme>=2.0.0).
+- Updated kernel patterns for correct analysis in zoomer.
+- Updated trace parser to handle unknown event names and values between `start_array` and `end_array`.
 
 #### Fixed
 - Fixed placeholder author email in setup.py.
+- Fixed empty DataFrame crash when `ProfilerStep` markers are missing.
+- Fixed typo: `shortern_names` → `shorten_names`.
+- Fixed spelling: "Dowloading" → "Downloading" in print statement.
+- Fixed spelling: "Crttical" → "Critical" in error message.
+- Return `False` instead of raising an error if critical path graph validation fails.
+
+#### Performance
+- Optimized GPU kernel annotation association with indexed symbol table lookups.
+- Faster trimming of trace events.
+- Switched to `to_numeric` in `normalize_gpu_stream_numbers` for improved performance.
 
 
 ## [0.5.0] - 2023-05-27

--- a/hta/common/constants.py
+++ b/hta/common/constants.py
@@ -2,7 +2,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-strict
+
 # The Max queue size is not really documented and is an implementation detail
 # https://forums.developer.nvidia.com/t/maximum-number-of-operations-in-a-stream/255260
 # We anecdotally see 1022 - 1024 to cause blocking of runtime operations.
 CUDA_MAX_LAUNCH_QUEUE_PER_STREAM: int = 1024
+
+# Max valid trace event duration. Events beyond this are corrupted (CUPTI timestamp overflow).
+MAX_EVENT_DURATION_US: int = 604_800_000_000  # 7 days in microseconds

--- a/hta/configs/parser_config.py
+++ b/hta/configs/parser_config.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import Dict, List, Optional, Set, Union
 
 import pandas as pd
+from hta.common.constants import MAX_EVENT_DURATION_US
 from hta.configs.default_values import AttributeSpec, EventArgs, ValueType
 from hta.configs.event_args_yaml_parser import (
     parse_event_args_yaml,
@@ -113,6 +114,10 @@ class ParserConfig:
         # config to convert ts to nearest integer
         self.convert_ts_to_integer = convert_ts_to_integer
 
+        # Max valid event duration in microseconds. Events exceeding this are
+        # dropped as corrupted (e.g. CUPTI timestamp overflow). Set to None to disable.
+        self.max_event_duration_us: Optional[int] = MAX_EVENT_DURATION_US
+
     def clone(self) -> "ParserConfig":
         return copy.deepcopy(self)
 
@@ -160,6 +165,7 @@ class ParserConfig:
         _DEFAULT_PARSER_CONFIG.set_parse_all_args(cfg.parse_all_args)
         _DEFAULT_PARSER_CONFIG.set_args_selector(cfg.selected_arg_keys)
         _DEFAULT_PARSER_CONFIG.set_skip_event_types(cfg.skip_event_types)
+        _DEFAULT_PARSER_CONFIG.max_event_duration_us = cfg.max_event_duration_us
 
     @classmethod
     def get_minimum_args(

--- a/tests/test_parser_config.py
+++ b/tests/test_parser_config.py
@@ -307,6 +307,19 @@ class ParserConfigTestCase(unittest.TestCase):
         self.assertIn("parser_backend=", repr_str)
         self.assertIn("version=", repr_str)
 
+    def test_default_max_event_duration(self) -> None:
+        """ParserConfig should default max_event_duration_us to 7 days in microseconds."""
+        cfg = ParserConfig()
+        seven_days_us = 7 * 24 * 60 * 60 * 1_000_000
+        self.assertEqual(cfg.max_event_duration_us, seven_days_us)
+
+    def test_set_default_cfg_propagates_max_event_duration(self) -> None:
+        """set_default_cfg should propagate max_event_duration_us to the global default."""
+        custom_cfg = ParserConfig()
+        custom_cfg.max_event_duration_us = 999
+        ParserConfig.set_default_cfg(custom_cfg)
+        self.assertEqual(ParserConfig.get_default_cfg().max_event_duration_us, 999)
+
 
 class TestParseEventArgsYaml(unittest.TestCase):
     @data_provider(


### PR DESCRIPTION
Summary:
**Purpose:** Prepare the v0.6.0 release of HTA, the first release in nearly 3 years.

**Type:** Infrastructure update

**Changes:**
- Updated CHANGELOG.md with all changes since v0.5.0 (features, bug fixes, performance improvements, infrastructure updates) and set the release date to 2026-04-08.
- Added fb/docs/RELEASE_NOTES_v0.6.0.md with a user-friendly release summary for the GitHub release page.
- Added fb/docs/RELEASING.md with end-to-end release process documentation including version bumping, changelog updates, ShipIt verification, GitHub release creation, PyPI publishing, and user guide update instructions.
- Updated CLAUDE.md default title tag from [HTA] to [HTA OSS].

Reviewed By: CptGit

Differential Revision: D100073873


