### PR TITLE
Handle metadata-only traces gracefully instead of crashing with KeyError

### DIFF
--- a/hta/common/trace.py
+++ b/hta/common/trace.py
@@ -258,6 +258,13 @@ def parse_trace_file(
 
     meta, df, local_symbol_table = parse_trace_dataframe(trace_file_path, cfg)
 
+    if df.empty:
+        logger.warning(
+            f"No analyzable events in {trace_file_path}. "
+            f"The trace may contain only metadata events."
+        )
+        return meta, df, local_symbol_table
+
     # add fwd bwd links between CPU ops
     add_fwd_bwd_links(df)
 
@@ -428,6 +435,8 @@ class Trace:
         )
         self.align_and_filter_trace(include_last_profiler_step)
         for rank, df in self.traces.items():
+            if df.empty:
+                continue
             df = self.traces[rank].set_index("index", drop=False)
             df.index.names = [None]
             self.traces[rank] = df
@@ -447,6 +456,11 @@ class Trace:
                 self.traces[rank],
                 local_symbol_table,
             ) = parse_trace_file(trace_filepath, self.parser_config)
+            if self.traces[rank].empty:
+                logger.warning(f"Trace for rank {rank} has no analyzable events.")
+                del self.traces[rank]
+                del self.meta_data[rank]
+                return
             # update the global symbol table
             self.symbol_table.add_symbols(local_symbol_table.get_sym_table())
             # fix the encoding of the data frame
@@ -517,12 +531,21 @@ class Trace:
 
         # Now we update the IDs in the Dataframe using the global symbols table.
         global_map = self.symbol_table.get_sym_id_map()
+        empty_ranks = []
         for rank in ranks:
+            if self.traces[rank].empty:
+                logger.warning(f"Trace for rank {rank} has no analyzable events.")
+                empty_ranks.append(rank)
+                continue
             local_table = local_symbol_tables[rank].get_sym_table()
             for col in ["cat", "name"]:
                 self.traces[rank][col] = self.traces[rank][col].apply(
                     lambda idx, _lt=local_table: global_map[_lt[idx]]
                 )
+        for rank in empty_ranks:
+            del self.traces[rank]
+            if rank in self.meta_data:
+                del self.meta_data[rank]
 
         t1 = time.perf_counter()
         logger.warning(
@@ -572,6 +595,8 @@ class Trace:
         """
         Align the starting time across multiple ranks and filter events that belong to incomplete iterations.
         """
+        if not self.traces:
+            return
         self._align_all_ranks()
         self._filter_irrelevant_gpu_kernels(include_last_profiler_step)
 
@@ -708,8 +733,11 @@ class Trace:
         """
         Align dataframes for all ranks such that the earliest event starts at time 0.
         """
-        self.min_ts = min(trace_df["ts"].min() for trace_df in self.traces.values())
-        for rank, trace_df in self.traces.items():
+        non_empty = {r: df for r, df in self.traces.items() if not df.empty}
+        if not non_empty:
+            return
+        self.min_ts = min(df["ts"].min() for df in non_empty.values())
+        for rank, trace_df in non_empty.items():
             trace_df["ts"] = trace_df["ts"] - self.min_ts
             self.traces[rank] = trace_df
 

--- a/hta/common/trace_parser.py
+++ b/hta/common/trace_parser.py
@@ -290,6 +290,17 @@ def _compress_df(
     """
     cfg = cfg or ParserConfig.get_default_cfg()
 
+    # Guard: traces with only metadata events (phase 'M') have no 'dur' or 'cat'
+    # columns. Return an empty DataFrame instead of crashing downstream.
+    required_cols = {"dur", "cat"}
+    if not required_cols.issubset(set(df.columns)):
+        missing = required_cols - set(df.columns)
+        logger.warning(
+            f"Trace is missing required columns {missing} "
+            f"(likely contains only metadata events). Skipping."
+        )
+        return pd.DataFrame(), TraceSymbolTable()
+
     # drop rows with null values
     df.dropna(axis=0, subset=["dur", "cat"], inplace=True)
     df.drop(df[df["cat"] == "Trace"].index, inplace=True)

--- a/tests/test_trace_parse.py
+++ b/tests/test_trace_parse.py
@@ -13,6 +13,7 @@ import pandas as pd
 from hta.common.trace import parse_trace_dict, Trace
 from hta.common.trace_parser import (
     _auto_detect_parser_backend,
+    _compress_df,
     _open_trace_file,
     get_default_trace_parsing_backend,
     infer_gpu_type,
@@ -644,6 +645,89 @@ class TraceParseConfigTestCase(unittest.TestCase):
 
         # Validate results
         pd.testing.assert_frame_equal(fixed_df, expected_df)
+
+
+class TestMetadataOnlyTrace(unittest.TestCase):
+    """Test handling of traces with only metadata events (no dur/cat columns)."""
+
+    def test_compress_df_missing_dur_and_cat(self):
+        """_compress_df should return empty DataFrame when dur and cat columns are missing."""
+        # Simulate a trace with only metadata events (phase 'M')
+        metadata_events = [
+            {
+                "ph": "M",
+                "name": "process_name",
+                "pid": 1,
+                "tid": 1,
+                "ts": 0,
+                "args": {"name": "GPU 0"},
+            },
+            {
+                "ph": "M",
+                "name": "thread_name",
+                "pid": 1,
+                "tid": 2,
+                "ts": 0,
+                "args": {"name": "stream 7"},
+            },
+        ]
+        df = pd.DataFrame(metadata_events)
+        result_df, result_sym = _compress_df(df)
+        self.assertTrue(result_df.empty)
+        self.assertIsInstance(result_sym, TraceSymbolTable)
+
+    def test_compress_df_with_valid_events(self):
+        """_compress_df should work normally when dur and cat columns exist."""
+        events = [
+            {
+                "ph": "X",
+                "name": "kernel_a",
+                "cat": "Kernel",
+                "pid": 1,
+                "tid": 1,
+                "ts": 100,
+                "dur": 50,
+            },
+            {
+                "ph": "X",
+                "name": "kernel_b",
+                "cat": "Kernel",
+                "pid": 1,
+                "tid": 1,
+                "ts": 200,
+                "dur": 30,
+            },
+        ]
+        df = pd.DataFrame(events)
+        result_df, result_sym = _compress_df(df)
+        self.assertFalse(result_df.empty)
+        self.assertEqual(len(result_df), 2)
+
+    def test_compress_df_mixed_events_filters_nulls(self):
+        """_compress_df should drop rows where dur/cat are null in mixed traces."""
+        events = [
+            {
+                "ph": "X",
+                "name": "kernel_a",
+                "cat": "Kernel",
+                "pid": 1,
+                "tid": 1,
+                "ts": 100,
+                "dur": 50,
+            },
+            {
+                "ph": "M",
+                "name": "process_name",
+                "pid": 1,
+                "tid": 1,
+                "ts": 0,
+                "cat": None,
+                "dur": None,
+            },
+        ]
+        df = pd.DataFrame(events)
+        result_df, result_sym = _compress_df(df)
+        self.assertEqual(len(result_df), 1)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
Summary:
Some GPU traces contain only metadata events (Chrome Trace phase 'M') with no kernel/operator events. These traces lack 'dur' and 'cat' columns, causing a KeyError crash in HTA's _compress_df when it calls df.dropna(subset=["dur", "cat"]).

Root cause: _compress_df assumes 'dur' and 'cat' columns always exist in the DataFrame. When a trace has only metadata events (e.g. process_name, thread_name), these columns are absent.

Fix:
1. Added a guard in _compress_df (trace_parser.py) to check for required columns before calling dropna. Returns empty DataFrame + empty TraceSymbolTable when columns are missing.
2. Added early return in parse_trace_file (trace.py) when DataFrame is empty, preventing downstream KeyError on df["ts"] + df["dur"].
3. Added empty-trace guards in Trace.parse_single_rank, parse_multiple_ranks, load_traces, and _align_all_ranks to prevent crashes when empty traces propagate through the system.

Differential Revision: D100558869


