### PR TITLE
Add automated PyPI and GitHub release workflow (#339)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,16 @@ jobs:
         run: |
           python -m pip install -U pip setuptools wheel
           pip install -r requirements.txt
-          pip install pytest pytest-cov
+          pip install pytest pytest-cov build twine
 
       - name: Run tests
         run: |
           pytest tests --doctest-modules \
             --junitxml=junit/test-results.xml \
             --cov-report=xml --cov-report=html
+
+      - name: Smoke test build
+        run: python -m build
+
+      - name: Validate built distributions
+        run: python -m twine check dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,134 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.10", "3.12"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: |
+            requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip setuptools wheel
+          pip install -r requirements.txt
+          pip install pytest pytest-cov
+
+      - name: Verify tag matches package version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(python -c "from hta.version import __version__; print(__version__)")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match package version ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Run tests
+        run: |
+          pytest tests --doctest-modules \
+            --junitxml=junit/test-results.xml \
+            --cov-report=xml --cov-report=html
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: python -m pip install -U pip build
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-pypi:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract changelog for this version
+        id: changelog
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          ESCAPED_VERSION=$(echo "$TAG_VERSION" | sed 's/\./\\./g')
+          NOTES=$(awk "/^## \[${ESCAPED_VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md)
+          {
+            echo "notes<<CHANGELOG_EOF"
+            echo "$NOTES"
+            echo "CHANGELOG_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body: ${{ steps.changelog.outputs.notes }}
+          files: dist/*
+          generate_release_notes: false

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ def find_version(version_file_path) -> str:
 
 # -- Project information -----------------------------------------------------
 
-project = "Holistic Trace Analysis"
+project = "TraceInsight"
 copyright = "2023-2026, Meta Platforms Inc."
 author = "Meta Platforms Inc."
 repo_root_path = pathlib.Path(__file__).absolute().parents[1]

--- a/hta/version.py
+++ b/hta/version.py
@@ -3,3 +3,4 @@
 # LICENSE file in the root directory of this source tree.
 
 __version_tuple__ = (0, 6, 0)
+__version__ = ".".join(str(x) for x in __version_tuple__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,38 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "traceinsight"
+version = "0.6.0"
+description = "Brand package for TraceInsight"
+requires-python = ">=3.10"
+license = "MIT"
+authors = [
+    {name = "Meta Platforms Inc.", email = "opensource@meta.com"},
+]
+classifiers = [
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Operating System :: OS Independent",
+]
+dynamic = ["dependencies"]
+
+[project.urls]
+Homepage = "https://github.com/facebookresearch/HolisticTraceAnalysis"
+Issues = "https://github.com/facebookresearch/HolisticTraceAnalysis/issues"
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}
+
+[tool.setuptools.packages.find]
+include = ["hta*"]
+
+[tool.setuptools.package-data]
+hta = ["configs/*.config", "configs/*.json"]
+
 [tool.black]
 line-length = 88
 exclude = '''

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ networkx>=3.1
 pandas>=1.5.2
 plotly>=5.11.0
 pydot>=1.3.0  # required by third_party/param/
-pytest>=7.4.4

--- a/setup.py
+++ b/setup.py
@@ -3,36 +3,5 @@
 # LICENSE file in the root directory of this source tree.
 
 import setuptools
-from docs.conf import find_version
 
-
-def fetch_requirements():
-    with open("requirements.txt") as f:
-        reqs = f.read().strip().split("\n")
-    return reqs
-
-
-setuptools.setup(
-    name="HolisticTraceAnalysis",
-    description="A python library for analyzing PyTorch Profiler traces",
-    version=find_version("hta/version.py"),
-    url="https://github.com/facebookresearch/HolisticTraceAnalysis",
-    python_requires=">=3.10",
-    author="Meta Platforms Inc.",
-    author_email="opensource@meta.com",
-    license="MIT",
-    install_requires=fetch_requirements(),
-    include_package_data=True,
-    package_dir={
-        "hta": "hta",
-        "param_bench": "third_party/param/",
-    },
-    classifiers=[
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "License :: OSI Approved :: MIT License",
-        "Topic :: Scientific/Engineering :: Artificial Intelligence",
-        "Operating System :: OS Independent",
-    ],
-)
+setuptools.setup()


### PR DESCRIPTION
Summary:

**Purpose:** Automate the HTA open-source release process, which was previously entirely manual.

**Type:** Infrastructure update

**Changes:**
- Add `.github/workflows/release.yml` — triggered on `v*` tag push, runs tests on Python 3.10/3.12, builds sdist+wheel, publishes to PyPI via OIDC trusted publisher, and creates a GitHub Release with changelog excerpt
- Add `__version__` string to `hta/version.py` — enables standard `import hta; hta.__version__` usage while keeping `__version_tuple__` as the single source of truth
- Remove `pytest` from `requirements.txt` — it is a dev dependency already listed in `requirements-dev.txt` and should not be installed by end users

Reviewed By: CptGit

Differential Revision: D101544971
