### PR TITLE
Fix negative mean kernel duration caused by sub-microsecond events after timestamp rounding (Fixes #317)

### DIFF
--- a/hta/common/trace_parser.py
+++ b/hta/common/trace_parser.py
@@ -305,6 +305,19 @@ def _compress_df(
     df.dropna(axis=0, subset=["dur", "cat"], inplace=True)
     df.drop(df[df["cat"] == "Trace"].index, inplace=True)
 
+    # drop events with non-positive duration; these can appear after timestamp
+    # rounding (round_down_time_stamps) where ceil(ts) > floor(end) for very
+    # short sub-microsecond events, and would produce negative mean durations
+    # in downstream aggregations such as get_gpu_kernel_breakdown().
+    negative_dur_mask = df["dur"] < 0
+    if negative_dur_mask.any():
+        n_dropped = int(negative_dur_mask.sum())
+        logger.warning(
+            f"Dropping {n_dropped} event(s) with negative duration, likely caused "
+            f"by sub-microsecond events after timestamp rounding."
+        )
+        df.drop(df[negative_dur_mask].index, inplace=True)
+
     # drop columns
     columns_to_drop = {"ph", "id", "bp", "s"}.intersection(set(df.columns))
     df.drop(list(columns_to_drop), axis=1, inplace=True)

--- a/tests/test_trace_parse.py
+++ b/tests/test_trace_parse.py
@@ -729,6 +729,50 @@ class TestMetadataOnlyTrace(unittest.TestCase):
         result_df, result_sym = _compress_df(df)
         self.assertEqual(len(result_df), 1)
 
+    def test_compress_df_drops_negative_duration_events(self):
+        """_compress_df should drop events with negative dur.
+
+        Sub-microsecond events can get negative durations after timestamp
+        rounding (round_down_time_stamps), which in turn causes negative mean
+        kernel durations in get_gpu_kernel_breakdown() (#317).
+        """
+        events = [
+            # Valid event: should be kept
+            {
+                "name": "kernel_a",
+                "cat": "Kernel",
+                "pid": 1,
+                "tid": 1,
+                "ts": 100,
+                "dur": 50,
+            },
+            # Negative-duration event produced by rounding: must be dropped
+            {
+                "name": "kernel_b",
+                "cat": "Kernel",
+                "pid": 1,
+                "tid": 1,
+                "ts": 101,
+                "dur": -1,
+            },
+            # Another valid event: should be kept
+            {
+                "name": "kernel_c",
+                "cat": "Kernel",
+                "pid": 1,
+                "tid": 1,
+                "ts": 200,
+                "dur": 30,
+            },
+        ]
+        df = pd.DataFrame(events)
+        result_df, _ = _compress_df(df)
+
+        # The two valid events should survive; the negative-dur one is dropped
+        self.assertEqual(len(result_df), 2)
+        # All remaining durations must be non-negative
+        self.assertTrue((result_df["dur"] >= 0).all())
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## What does this PR do?

Fixes #317

`get_gpu_kernel_breakdown()` (and other aggregations using `_aggr_gpu_kernel_time`) can return negative mean kernel durations when traces contain sub-microsecond events that were recorded with nanosecond-resolution timestamps.

**Root cause:** `round_down_time_stamps` adjusts float timestamps by ceiling `ts` and flooring `end` before converting to integer microseconds. For events shorter than 1 µs this can produce `ceil(ts) > floor(end)`, yielding `dur = end - ts < 0`. Those events then reach `_aggr_gpu_kernel_time`, where `pd.DataFrame.groupby(...).agg("mean")` computes a negative mean.

**Fix:** Drop events with `dur < 0` inside `_compress_df`, the central post-parse normalization function. A warning is logged so users can see how many such events were discarded. This mirrors the existing `dropna` step for `dur`/`cat` nulls directly above it.

**Example of how a negative `dur` arises:**

```python
import math
ts, dur = 100.7, 0.2   # from a sub-µs ns-resolution kernel
end = ts + dur          # 100.9
ts_rounded  = math.ceil(ts)    # 101
end_rounded = math.floor(end)  # 100
dur_rounded = end_rounded - ts_rounded  # -1
```

## Before submitting

- [x] Was this discussed/approved via a Github issue? Yes, issue #317
- [x] Did you write any new necessary tests? Yes, `test_compress_df_drops_negative_duration_events` in `tests/test_trace_parse.py`
- [ ] Did you make sure to update the docs? N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)? N/A (bug fix)