### PR TITLE
Add POST_PROCESSED_ANNOTATION_CATEGORY_PATTERN to OSS HTA (#343)

### DIFF
--- a/hta/common/types.py
+++ b/hta/common/types.py
@@ -143,7 +143,7 @@ KERNEL_LAUNCH_CATEGORY_PATTERN = GroupingPattern(
 )
 
 CPU_OP_CATEGORY_PATTERN: GroupingPattern = GroupingPattern(
-    re.compile("(cpu_op)|(user_annotation)"), False, "CPU Ops"
+    re.compile(r"(^cpu_op)|(^user_annotation$)"), False, "CPU Ops"
 )
 
 DEVICE_RUNTIME_CATEGORY_PATTERN = GroupingPattern(
@@ -160,16 +160,22 @@ GPU_EVENT_CATEGORY_PATTERN: GroupingPattern = GroupingPattern(
     inverse_match=False,
 )
 
+POST_PROCESSED_ANNOTATION_CATEGORY_PATTERN: GroupingPattern = GroupingPattern(
+    group_name="Post-Processed Annotations",
+    pattern=re.compile(r"(^gpu_user_annotation)"),
+    inverse_match=False,
+)
+
 CPU_EVENTS_CATEGORY_PATTERN: GroupingPattern = GroupingPattern(
     group_name="CPU Events",
-    pattern=re.compile(r"(cpu_op)|(user_annotation)|(^(.+)_runtime)"),
+    pattern=re.compile(r"(^cpu_op)|(^user_annotation$)|(^(.+)_runtime)"),
     inverse_match=False,
 )
 
 CPU_AND_GPU_EVENTS_CATEGORY_PATTERN: GroupingPattern = GroupingPattern(
     group_name="CPU/GPU Events",
     pattern=re.compile(
-        r"(cpu_op)|(user_annotation)|(cuda_runtime)"
+        r"(^cpu_op)|(^user_annotation$)|(cuda_runtime)"
         + r"|(.*kernel)|(^gpu_mem)|(^mtia_ccp_events)|(^cuda_sync)"
     ),
     inverse_match=False,


### PR DESCRIPTION
Summary:

Add `POST_PROCESSED_ANNOTATION_CATEGORY_PATTERN` to OSS HTA's `types.py` to
recognize `gpu_user_annotation` as its own distinct event category. These are
synthetic annotations added by Kineto during trace post-processing — they are
neither real GPU events nor CPU events.

Also tighten `CPU_OP_CATEGORY_PATTERN`, `CPU_EVENTS_CATEGORY_PATTERN`, and
`CPU_AND_GPU_EVENTS_CATEGORY_PATTERN` to use `(^user_annotation$)` instead
of `(user_annotation)` to defensively exclude `gpu_user_annotation` from
matching as a CPU event category.

Reviewed By: fengxizhou

Differential Revision: D101907220


