### PR TITLE
chore: declare contents: read on ci and pre-commit workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ env:
   # Opt in early for Node runtime migration of JS-based actions
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,6 +8,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Two CI workflows currently inherit the default GITHUB_TOKEN scope: ci.yml runs pytest + lint, pre-commit.yml runs the configured pre-commit hooks. Neither writes back. release.yml in this repo already declares per-job permissions; matching the workflow-level pattern for the remaining two.