### PR TITLE
Add unit tests for utils, validate_trace, and default_values modules

### DIFF
--- a/tests/test_default_values.py
+++ b/tests/test_default_values.py
@@ -1,0 +1,110 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+from hta.configs.default_values import AttributeSpec, ValueType, YamlVersion
+
+
+class TestYamlVersion(unittest.TestCase):
+    def test_get_version_str(self) -> None:
+        v = YamlVersion(1, 2, 3)
+        self.assertEqual(v.get_version_str(), "1.2.3")
+
+    def test_from_string_valid(self) -> None:
+        v = YamlVersion.from_string("1.0.0")
+        self.assertEqual(v.major, 1)
+        self.assertEqual(v.minor, 0)
+        self.assertEqual(v.patch, 0)
+
+    def test_from_string_multidigit(self) -> None:
+        v = YamlVersion.from_string("12.34.56")
+        self.assertEqual(v.major, 12)
+        self.assertEqual(v.minor, 34)
+        self.assertEqual(v.patch, 56)
+
+    def test_from_string_invalid_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            YamlVersion.from_string("1.0")
+
+    def test_from_string_non_numeric_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            YamlVersion.from_string("a.b.c")
+
+    def test_from_string_empty_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            YamlVersion.from_string("")
+
+    def test_roundtrip(self) -> None:
+        original = "2.5.10"
+        v = YamlVersion.from_string(original)
+        self.assertEqual(v.get_version_str(), original)
+
+    def test_named_tuple_fields(self) -> None:
+        v = YamlVersion(major=1, minor=2, patch=3)
+        self.assertEqual(v[0], 1)
+        self.assertEqual(v[1], 2)
+        self.assertEqual(v[2], 3)
+
+    def test_comparison(self) -> None:
+        v1 = YamlVersion(1, 0, 0)
+        v2 = YamlVersion(1, 0, 1)
+        v3 = YamlVersion(2, 0, 0)
+        self.assertLess(v1, v2)
+        self.assertLess(v2, v3)
+        self.assertEqual(v1, YamlVersion(1, 0, 0))
+
+
+class TestValueType(unittest.TestCase):
+    def test_enum_values(self) -> None:
+        self.assertEqual(ValueType.Int.value, 1)
+        self.assertEqual(ValueType.Float.value, 2)
+        self.assertEqual(ValueType.String.value, 3)
+        self.assertEqual(ValueType.Object.value, 4)
+
+    def test_all_types_exist(self) -> None:
+        expected_names = {"Int", "Float", "String", "Object"}
+        actual_names = {vt.name for vt in ValueType}
+        self.assertEqual(actual_names, expected_names)
+
+
+class TestAttributeSpec(unittest.TestCase):
+    def test_equality_same_values(self) -> None:
+        v = YamlVersion(1, 0, 0)
+        a1 = AttributeSpec("col", "raw", ValueType.Int, 0, v)
+        a2 = AttributeSpec("col", "raw", ValueType.Int, 0, v)
+        self.assertEqual(a1, a2)
+
+    def test_inequality_different_name(self) -> None:
+        v = YamlVersion(1, 0, 0)
+        a1 = AttributeSpec("col1", "raw", ValueType.Int, 0, v)
+        a2 = AttributeSpec("col2", "raw", ValueType.Int, 0, v)
+        self.assertNotEqual(a1, a2)
+
+    def test_inequality_different_type(self) -> None:
+        v = YamlVersion(1, 0, 0)
+        a1 = AttributeSpec("col", "raw", ValueType.Int, 0, v)
+        a2 = AttributeSpec("col", "raw", ValueType.Float, 0.0, v)
+        self.assertNotEqual(a1, a2)
+
+    def test_equality_ignores_min_version(self) -> None:
+        v1 = YamlVersion(1, 0, 0)
+        v2 = YamlVersion(2, 0, 0)
+        a1 = AttributeSpec("col", "raw", ValueType.Int, 0, v1)
+        a2 = AttributeSpec("col", "raw", ValueType.Int, 0, v2)
+        self.assertEqual(a1, a2)
+
+    def test_not_equal_to_non_attributespec(self) -> None:
+        v = YamlVersion(1, 0, 0)
+        a = AttributeSpec("col", "raw", ValueType.Int, 0, v)
+        self.assertNotEqual(a, "not_an_attributespec")
+
+    def test_field_access(self) -> None:
+        v = YamlVersion(1, 0, 0)
+        a = AttributeSpec("my_col", "my_raw", ValueType.String, "default", v)
+        self.assertEqual(a.name, "my_col")
+        self.assertEqual(a.raw_name, "my_raw")
+        self.assertEqual(a.value_type, ValueType.String)
+        self.assertEqual(a.default_value, "default")
+        self.assertEqual(a.min_supported_version, v)

--- a/tests/test_utils_extended.py
+++ b/tests/test_utils_extended.py
@@ -1,0 +1,219 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import pandas as pd
+from hta.utils.utils import (
+    flatten_column_names,
+    get_kernel_type,
+    get_memory_kernel_type,
+    get_mp_pool_size,
+    get_value_from_dict,
+    is_comm_kernel,
+    is_compute_kernel,
+    is_computer_kernel,
+    is_memory_kernel,
+    KernelType,
+    merge_kernel_intervals,
+    normalize_gpu_stream_numbers,
+    normalize_path,
+)
+
+
+class TestNormalizePath(unittest.TestCase):
+    def test_absolute_path_unchanged(self) -> None:
+        self.assertEqual(normalize_path("/tmp/trace"), "/tmp/trace")
+
+    def test_relative_dot_slash_path(self) -> None:
+        result = normalize_path("./subdir")
+        self.assertTrue(result.endswith("subdir"))
+        self.assertFalse(result.startswith("./"))
+
+    def test_dot_slash_only(self) -> None:
+        result = normalize_path("./")
+        self.assertFalse(result.endswith("/"))
+        self.assertTrue(len(result) > 0)
+
+    def test_tilde_path(self) -> None:
+        result = normalize_path("~/mydir")
+        self.assertTrue(result.endswith("mydir"))
+        self.assertFalse(result.startswith("~"))
+
+    def test_tilde_only(self) -> None:
+        result = normalize_path("~/")
+        self.assertFalse(result.endswith("/"))
+        self.assertTrue(len(result) > 0)
+
+    def test_plain_path_unchanged(self) -> None:
+        self.assertEqual(normalize_path("some/path"), "some/path")
+
+
+class TestKernelClassification(unittest.TestCase):
+    def test_nccl_is_comm_kernel(self) -> None:
+        self.assertTrue(is_comm_kernel("ncclAllReduce"))
+        self.assertTrue(is_comm_kernel("ncclKernel_SendRecv"))
+
+    def test_compute_kernel_not_comm(self) -> None:
+        self.assertFalse(is_comm_kernel("volta_sgemm"))
+
+    def test_memcpy_is_memory_kernel(self) -> None:
+        self.assertTrue(is_memory_kernel("Memcpy DtoH"))
+        self.assertTrue(is_memory_kernel("Memcpy HtoD"))
+        self.assertTrue(is_memory_kernel("Memset"))
+
+    def test_compute_kernel_not_memory(self) -> None:
+        self.assertFalse(is_memory_kernel("volta_sgemm"))
+
+    def test_sgemm_is_compute_kernel(self) -> None:
+        self.assertTrue(is_compute_kernel("volta_sgemm"))
+
+    def test_nccl_not_compute_kernel(self) -> None:
+        self.assertFalse(is_compute_kernel("ncclAllReduce"))
+
+    def test_memcpy_not_compute_kernel(self) -> None:
+        self.assertFalse(is_compute_kernel("Memcpy DtoH"))
+
+    def test_is_computer_kernel_deprecated_alias(self) -> None:
+        self.assertEqual(
+            is_computer_kernel("volta_sgemm"), is_compute_kernel("volta_sgemm")
+        )
+        self.assertEqual(
+            is_computer_kernel("ncclAllReduce"), is_compute_kernel("ncclAllReduce")
+        )
+
+
+class TestGetKernelType(unittest.TestCase):
+    def test_communication_kernel(self) -> None:
+        self.assertEqual(
+            get_kernel_type("ncclAllReduce"), KernelType.COMMUNICATION.name
+        )
+
+    def test_memory_kernel(self) -> None:
+        self.assertEqual(get_kernel_type("Memcpy DtoH"), KernelType.MEMORY.name)
+
+    def test_computation_kernel(self) -> None:
+        self.assertEqual(get_kernel_type("volta_sgemm"), KernelType.COMPUTATION.name)
+
+    def test_other_kernel(self) -> None:
+        self.assertEqual(
+            get_kernel_type("cudaStreamSynchronize"), KernelType.OTHER.name
+        )
+
+
+class TestGetMemoryKernelType(unittest.TestCase):
+    def test_memset(self) -> None:
+        self.assertEqual(get_memory_kernel_type("Memset (Device)"), "Memset")
+
+    def test_memcpy_dtoh(self) -> None:
+        self.assertEqual(get_memory_kernel_type("Memcpy DtoH"), "Memcpy DtoH")
+
+    def test_memcpy_htod(self) -> None:
+        self.assertEqual(get_memory_kernel_type("Memcpy HtoD"), "Memcpy HtoD")
+
+    def test_memcpy_dtod(self) -> None:
+        self.assertEqual(get_memory_kernel_type("Memcpy DtoD"), "Memcpy DtoD")
+
+    def test_non_memcpy_prefix(self) -> None:
+        self.assertEqual(get_memory_kernel_type("SomeOther"), "Memcpy Unknown")
+
+
+class TestMergeKernelIntervals(unittest.TestCase):
+    def test_non_overlapping_intervals(self) -> None:
+        df = pd.DataFrame({"ts": [0, 100, 200], "dur": [50, 50, 50]})
+        result = merge_kernel_intervals(df)
+        self.assertEqual(len(result), 3)
+
+    def test_overlapping_intervals_merged(self) -> None:
+        df = pd.DataFrame({"ts": [0, 30, 200], "dur": [50, 50, 50]})
+        result = merge_kernel_intervals(df)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result.iloc[0]["ts"], 0)
+        self.assertEqual(result.iloc[0]["end"], 80)
+        self.assertEqual(result.iloc[1]["ts"], 200)
+        self.assertEqual(result.iloc[1]["end"], 250)
+
+    def test_fully_contained_interval(self) -> None:
+        df = pd.DataFrame({"ts": [0, 10], "dur": [100, 20]})
+        result = merge_kernel_intervals(df)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result.iloc[0]["ts"], 0)
+        self.assertEqual(result.iloc[0]["end"], 100)
+
+    def test_single_interval(self) -> None:
+        df = pd.DataFrame({"ts": [10], "dur": [50]})
+        result = merge_kernel_intervals(df)
+        self.assertEqual(len(result), 1)
+
+
+class TestFlattenColumnNames(unittest.TestCase):
+    def test_multi_index_columns_flattened(self) -> None:
+        arrays = [["A", "A", "B"], ["one", "two", "one"]]
+        tuples = list(zip(*arrays))
+        index = pd.MultiIndex.from_tuples(tuples)
+        df = pd.DataFrame([[1, 2, 3]], columns=index)
+        flatten_column_names(df)
+        self.assertEqual(list(df.columns), ["A_one", "A_two", "B_one"])
+
+    def test_single_index_columns_unchanged(self) -> None:
+        df = pd.DataFrame({"a": [1], "b": [2]})
+        flatten_column_names(df)
+        self.assertEqual(list(df.columns), ["a", "b"])
+
+
+class TestGetMpPoolSize(unittest.TestCase):
+    def test_returns_positive_integer(self) -> None:
+        result = get_mp_pool_size(1024, 10)
+        self.assertGreater(result, 0)
+
+    def test_limited_by_num_objs(self) -> None:
+        result = get_mp_pool_size(1, 2)
+        self.assertLessEqual(result, 2)
+
+    def test_large_obj_size_limits_pool(self) -> None:
+        result = get_mp_pool_size(10**15, 100)
+        self.assertLessEqual(result, 100)
+
+
+class TestNormalizeGpuStreamNumbers(unittest.TestCase):
+    def test_integer_streams_unchanged(self) -> None:
+        df = pd.DataFrame({"stream": [1, 2, 3]})
+        normalize_gpu_stream_numbers(df)
+        self.assertEqual(df["stream"].tolist(), [1, 2, 3])
+
+    def test_non_numeric_stream_becomes_minus_one(self) -> None:
+        df = pd.DataFrame({"stream": ["abc", "2", "xyz"]})
+        normalize_gpu_stream_numbers(df)
+        self.assertEqual(df["stream"].tolist(), [-1, 2, -1])
+
+    def test_no_stream_column(self) -> None:
+        df = pd.DataFrame({"other": [1, 2]})
+        normalize_gpu_stream_numbers(df)
+        self.assertNotIn("stream", df.columns)
+
+
+class TestGetValueFromDict(unittest.TestCase):
+    def test_simple_key(self) -> None:
+        d = {"a": 1, "b": 2}
+        self.assertEqual(get_value_from_dict(d, "a"), 1)
+
+    def test_nested_key(self) -> None:
+        d = {"a": {"b": {"c": 42}}}
+        self.assertEqual(get_value_from_dict(d, "a.b.c"), 42)
+
+    def test_missing_key_returns_default(self) -> None:
+        d = {"a": 1}
+        self.assertEqual(get_value_from_dict(d, "b", "default"), "default")
+
+    def test_missing_nested_key_returns_default(self) -> None:
+        d = {"a": {"b": 1}}
+        self.assertIsNone(get_value_from_dict(d, "a.c"))
+
+    def test_default_none(self) -> None:
+        d = {"a": 1}
+        self.assertIsNone(get_value_from_dict(d, "z"))
+
+    def test_non_dict_intermediate(self) -> None:
+        d = {"a": 5}
+        self.assertEqual(get_value_from_dict(d, "a.b", "fallback"), "fallback")

--- a/tests/test_validate_trace.py
+++ b/tests/test_validate_trace.py
@@ -1,0 +1,216 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import gzip
+import json
+import os
+import tempfile
+import unittest
+from collections import Counter, defaultdict
+
+import pandas as pd
+from hta.configs.default_values import ValueType
+from hta.configs.parser_config import ParserConfig
+from hta.utils.validate_trace import (
+    _check_args,
+    _get_argument_value_types,
+    get_argument_spec,
+    get_expected_arguments,
+    validate_trace_format,
+)
+
+
+class TestGetArgumentSpec(unittest.TestCase):
+    def test_minimal_level(self) -> None:
+        result = get_argument_spec("minimal")
+        self.assertEqual(result, ParserConfig.ARGS_MINIMUM)
+
+    def test_standard_level(self) -> None:
+        result = get_argument_spec("standard")
+        self.assertEqual(result, ParserConfig.ARGS_DEFAULT)
+
+    def test_complete_level(self) -> None:
+        result = get_argument_spec("complete")
+        self.assertEqual(result, ParserConfig.ARGS_COMPLETE)
+
+    def test_invalid_level_raises(self) -> None:
+        with self.assertRaises(KeyError):
+            get_argument_spec("nonexistent")
+
+
+class TestGetExpectedArguments(unittest.TestCase):
+    def test_returns_dataframe_with_expected_columns(self) -> None:
+        specs = get_argument_spec("minimal")
+        df = get_expected_arguments(specs)
+        self.assertIsInstance(df, pd.DataFrame)
+        expected_cols = {
+            "arg_keys",
+            "arg_value_types",
+            "arg_default_values",
+            "trace_df_column_name",
+        }
+        self.assertEqual(set(df.columns), expected_cols)
+
+    def test_row_count_matches_specs(self) -> None:
+        specs = get_argument_spec("minimal")
+        df = get_expected_arguments(specs)
+        self.assertEqual(len(df), len(specs))
+
+    def test_values_match_attribute_specs(self) -> None:
+        specs = get_argument_spec("standard")
+        df = get_expected_arguments(specs)
+        for i, spec in enumerate(specs):
+            self.assertEqual(df.iloc[i]["arg_keys"], spec.raw_name)
+            self.assertEqual(df.iloc[i]["arg_value_types"], spec.value_type)
+            self.assertEqual(df.iloc[i]["trace_df_column_name"], spec.name)
+
+
+class TestGetArgumentValueTypes(unittest.TestCase):
+    def test_returns_dict_with_correct_structure(self) -> None:
+        specs = get_argument_spec("minimal")
+        df = get_expected_arguments(specs)
+        result = _get_argument_value_types(df)
+        self.assertIsInstance(result, dict)
+        for _key, value in result.items():
+            self.assertIsInstance(value, tuple)
+            self.assertEqual(len(value), 2)
+            self.assertIsInstance(value[0], ValueType)
+
+
+class TestCheckArgs(unittest.TestCase):
+    def test_matching_types_no_violations(self) -> None:
+        arg_type_map = {
+            "External id": (ValueType.Int, 0),
+            "name": (ValueType.String, ""),
+        }
+        skipped: Counter = Counter()
+        violations: defaultdict = defaultdict(str)
+        args = {"External id": 42, "name": "test_op"}
+        _check_args(args, arg_type_map, skipped, violations)
+        self.assertEqual(len(violations), 0)
+        self.assertEqual(len(skipped), 0)
+
+    def test_unknown_key_is_skipped(self) -> None:
+        arg_type_map = {"known_key": (ValueType.Int, 0)}
+        skipped: Counter = Counter()
+        violations: defaultdict = defaultdict(str)
+        args = {"unknown_key": 5}
+        _check_args(args, arg_type_map, skipped, violations)
+        self.assertIn("unknown_key", skipped)
+        self.assertEqual(skipped["unknown_key"], 1)
+
+    def test_type_violation_detected(self) -> None:
+        arg_type_map = {"my_int": (ValueType.Int, 0)}
+        skipped: Counter = Counter()
+        violations: defaultdict = defaultdict(str)
+        args = {"my_int": "not_an_int"}
+        _check_args(args, arg_type_map, skipped, violations)
+        self.assertIn("my_int", violations)
+
+    def test_int_float_compatible(self) -> None:
+        arg_type_map = {"my_float": (ValueType.Float, 0.0)}
+        skipped: Counter = Counter()
+        violations: defaultdict = defaultdict(str)
+        args = {"my_float": 5}
+        _check_args(args, arg_type_map, skipped, violations)
+        self.assertEqual(len(violations), 0)
+
+    def test_object_type_not_checked(self) -> None:
+        arg_type_map = {"obj": (ValueType.Object, {})}
+        skipped: Counter = Counter()
+        violations: defaultdict = defaultdict(str)
+        args = {"obj": "anything_goes"}
+        _check_args(args, arg_type_map, skipped, violations)
+        self.assertEqual(len(violations), 0)
+
+
+class TestValidateTraceFormat(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp_dir = tempfile.mkdtemp()
+
+    def tearDown(self) -> None:
+        for f in os.listdir(self._tmp_dir):
+            os.unlink(os.path.join(self._tmp_dir, f))
+        os.rmdir(self._tmp_dir)
+
+    def _write_trace_json(self, trace_data: dict, filename: str = "trace.json") -> str:
+        path = os.path.join(self._tmp_dir, filename)
+        with open(path, "w") as f:
+            json.dump(trace_data, f)
+        return path
+
+    def _write_trace_gz(self, trace_data: dict, filename: str = "trace.json.gz") -> str:
+        path = os.path.join(self._tmp_dir, filename)
+        with gzip.open(path, "wb") as f:
+            f.write(json.dumps(trace_data).encode("utf-8"))
+        return path
+
+    def test_valid_trace_passes(self) -> None:
+        trace_data = {
+            "traceEvents": [
+                {"name": "op1", "cat": "cpu_op", "ts": 100, "dur": 50, "args": {}},
+            ]
+        }
+        path = self._write_trace_json(trace_data)
+        ok, errors = validate_trace_format(path, level="minimal")
+        self.assertTrue(ok)
+        self.assertEqual(len(errors), 0)
+
+    def test_missing_trace_events_section(self) -> None:
+        trace_data = {"other_key": []}
+        path = self._write_trace_json(trace_data)
+        ok, errors = validate_trace_format(path)
+        self.assertFalse(ok)
+        self.assertIn("trace_data_error", errors)
+
+    def test_nonexistent_file(self) -> None:
+        ok, errors = validate_trace_format("/nonexistent/path/trace.json")
+        self.assertFalse(ok)
+        self.assertIn("trace_read_error", errors)
+
+    def test_gz_trace_format(self) -> None:
+        trace_data = {
+            "traceEvents": [
+                {"name": "op1", "cat": "cpu_op", "ts": 100, "dur": 50, "args": {}},
+            ]
+        }
+        path = self._write_trace_gz(trace_data)
+        ok, errors = validate_trace_format(path, level="minimal")
+        self.assertTrue(ok)
+
+    def test_type_violations_reported(self) -> None:
+        trace_data = {
+            "traceEvents": [
+                {
+                    "name": "op1",
+                    "cat": "cpu_op",
+                    "ts": 100,
+                    "dur": 50,
+                    "args": {"External id": "should_be_int"},
+                },
+            ]
+        }
+        path = self._write_trace_json(trace_data)
+        ok, errors = validate_trace_format(path, level="standard")
+        if not ok:
+            self.assertIn("type_violations", errors)
+
+    def test_skipped_arguments_reported_when_not_ignored(self) -> None:
+        trace_data = {
+            "traceEvents": [
+                {
+                    "name": "op1",
+                    "cat": "cpu_op",
+                    "ts": 100,
+                    "dur": 50,
+                    "args": {"some_unknown_arg": 123},
+                },
+            ]
+        }
+        path = self._write_trace_json(trace_data)
+        ok, errors = validate_trace_format(
+            path, level="minimal", ignore_missing_arguments=False
+        )
+        if not ok:
+            self.assertIn("skipped_arguments", errors)


### PR DESCRIPTION
Summary:
Add unit tests for three previously untested or under-tested modules in HolisticTraceAnalysis:

1. **`hta/utils/utils.py`** (test_utils_extended.py - 41 tests): Tests for `normalize_path`, kernel classification functions (`is_comm_kernel`, `is_memory_kernel`, `is_compute_kernel`), `get_kernel_type`, `get_memory_kernel_type`, `merge_kernel_intervals`, `flatten_column_names`, `get_mp_pool_size`, `normalize_gpu_stream_numbers`, and `get_value_from_dict`.

2. **`hta/utils/validate_trace.py`** (test_validate_trace.py - 19 tests): Tests for `get_argument_spec`, `get_expected_arguments`, `_get_argument_value_types`, `_check_args`, and `validate_trace_format` with both JSON and gzipped trace files.

3. **`hta/configs/default_values.py`** (test_default_values.py - 17 tests): Tests for `YamlVersion` (parsing, serialization, comparison), `ValueType` enum, and `AttributeSpec` equality semantics.

Total: 77 new unit tests covering real behavior without mocking.

Update: replace `defaultdict(int)` with `Counter()` in `test_validate_trace.py` to satisfy
FLAKE8 B910 (github-export-checks).

___

overriding_review_checks_triggers_an_audit_and_retroactive_review
Oncall Short Name: ads_model_platform

Reviewed By: fengxizhou

Differential Revision: D105039091


Signed-off-by: Yasha Singh <yashasingh@meta.com>