### PR TITLE
Fix/straggler nccl dev kernel prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 #### Fixed
-- Fixed straggler analysis not detecting communication kernels on NCCL >= 2.12 traces due to the `ncclDevKernel_*` kernel rename.
+- Fixed straggler analysis not detecting communication kernels on traces from modern NCCL versions due to the `ncclDevKernel_*` kernel rename.
 
 ## [0.6.1] - 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file. The format 
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+#### Fixed
+- Fixed straggler analysis not detecting communication kernels on NCCL >= 2.12 traces due to the `ncclDevKernel_*` kernel rename.
+
 ## [0.6.1] - 2026-04-21
 
 #### Fixed

--- a/hta/analyzers/straggler.py
+++ b/hta/analyzers/straggler.py
@@ -102,7 +102,11 @@ def _compute_normalized_start_time_of_significant_comm_kernels(
     # find all communication kernels
     sym_table = symbol_table.get_sym_table()
     sym_map = symbol_table.get_sym_id_map()
-    comm_op_ids = [sym_map[s] for s in sym_table if s.startswith("ncclKernel")]
+    comm_op_ids = [
+        sym_map[s]
+        for s in sym_table
+        if s.startswith(("ncclKernel", "ncclDevKernel"))
+    ]
     iterations = _get_unique_values(df, "iteration")
     ranks = _get_unique_values(df, "rank")
     df = df.loc[df["iteration"].isin(iterations)]


### PR DESCRIPTION
## What does this PR do?
 
Fixes https://github.com/facebookresearch/HolisticTraceAnalysis/issues/360 straggler analysis silently finding zero communication kernels on traces from modern NCCL builds.

Modern NCCL renamed its device kernels from ncclKernel_* to ncclDevKernel_* (e.g. ncclDevKernel_AllReduce_Sum_f32_RING_LL, ncclDevKernel_Generic).

## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [ ] Did you write any new necessary tests?
  - [x] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [x] Did you update the [changelog](https://github.com/facebookresearch/HolisticTraceAnalysis/blob/main/CHANGELOG.md)?
  - [ ] N/A
