### PR TITLE
Remove Pyre mode headers in 338 fbcode directories

### DIFF
--- a/hta/common/constants.py
+++ b/hta/common/constants.py
@@ -2,7 +2,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-strict
 
 # The Max queue size is not really documented and is an implementation detail
 # https://forums.developer.nvidia.com/t/maximum-number-of-operations-in-a-stream/255260

--- a/hta/configs/event_args_yaml_parser.py
+++ b/hta/configs/event_args_yaml_parser.py
@@ -1,7 +1,5 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-# pyre-strict
-
 
 import os
 from functools import lru_cache

--- a/hta/configs/parser_config.py
+++ b/hta/configs/parser_config.py
@@ -1,5 +1,3 @@
-# pyre-strict
-
 import copy
 import re
 from enum import Enum


### PR DESCRIPTION
Summary:
Remove standalone `# pyre-strict` and `# pyre-unsafe` mode headers from 1000 Python files across 338 fbcode directories.

Pyrefly type-checks all files in one consistent mode, so these legacy per-file mode headers no longer have an effect. Other Pyre directives and generated files are left unchanged.

Pyrefly is now the default type checker across FBCode so this diff introduces no functional changes.

drop-conflicts
#pyreupgrade

Reviewed By: maggiemoss

Differential Revision: D117751395


