### PR TITLE
Include MTIA runtimes in critical path graphs

### DIFF
--- a/hta/analyzers/critical_path_analysis.py
+++ b/hta/analyzers/critical_path_analysis.py
@@ -446,7 +446,7 @@ class CPGraph(nx.DiGraph):
         to represent in our graph"""
 
         operator_or_runtime_events_mask = (
-            self.symbol_table.get_operator_or_cuda_runtime_mask(self.trace_df)
+            self.symbol_table.get_operator_or_device_runtime_mask(self.trace_df)
         )
         data_loading_events_mask = self.symbol_table.get_events_mask(
             self.trace_df, self.data_load_events

--- a/hta/common/trace_symbol_table.py
+++ b/hta/common/trace_symbol_table.py
@@ -24,6 +24,31 @@ from hta.configs.default_values import MAX_NUM_PROCESSES_SMALL
 from hta.utils.utils import shorten_name
 
 
+_OPERATOR_OR_CUDA_RUNTIME_CATEGORIES = (
+    "cpu_op",
+    "cuda_driver",
+    "cuda_runtime",
+)
+_OPERATOR_OR_DEVICE_RUNTIME_CATEGORIES = (
+    *_OPERATOR_OR_CUDA_RUNTIME_CATEGORIES,
+    "mtia_runtime",
+)
+_RUNTIME_LAUNCH_EVENT_NAMES = (
+    "cudaLaunchKernel",
+    "cudaLaunchKernelExC",
+    "cuLaunchKernel",
+    "cuLaunchKernelEx",
+    "cudaMemcpyAsync",
+    "cudaMemsetAsync",
+    "runFunction - job_prep_and_submit_for_execution",
+    "hipLaunchKernel",
+    "hipExtModuleLaunchKernel",
+    "hipMemsetAsync",
+    "hipMemcpyAsync",
+    "hipMemcpyWithStream",
+)
+
+
 class _SymbolCollector:
     """
     To support a multiprocessing version of symbol table update, we use _SymbolCollector to a shared queue
@@ -301,59 +326,40 @@ class TraceSymbolTable:
             lambda i: self.sym_table[i] if (0 <= i < len(self.sym_table)) else ""
         )
 
-    # Use a number lower than -1 as a sentinel for missing symbols
+    # Retained for compatibility with external HTA callers. Internal mask
+    # construction does not substitute it for missing symbols.
     NULL: int = -128
 
-    def get_operator_or_cuda_runtime_mask(self, df: pd.DataFrame) -> pd.Series:
+    def get_operator_or_device_runtime_mask(self, df: pd.DataFrame) -> pd.Series:
         """Returns a boolean mask you can use with pandas dataframes
-        to filter events that are CUDA runtime events or operators."""
-        cpu_op_id = self.sym_index.get("cpu_op")
-        cuda_runtime_id = self.sym_index.get("cuda_driver", self.NULL)
-        cuda_driver_id = self.sym_index.get("cuda_runtime", self.NULL)
-        return (
-            (df["cat"] == cpu_op_id)
-            | (df["cat"] == cuda_runtime_id)
-            | (df["cat"] == cuda_driver_id)
+        to filter events that are device runtime events or operators."""
+        category_ids = self._get_existing_symbol_ids(
+            _OPERATOR_OR_DEVICE_RUNTIME_CATEGORIES
         )
+        return df["cat"].isin(category_ids)
+
+    def get_operator_or_cuda_runtime_mask(self, df: pd.DataFrame) -> pd.Series:
+        """Return the legacy CUDA-only mask for external HTA callers."""
+        category_ids = self._get_existing_symbol_ids(
+            _OPERATOR_OR_CUDA_RUNTIME_CATEGORIES
+        )
+        return df["cat"].isin(category_ids)
+
+    def _get_existing_symbol_ids(self, symbols: Iterable[str]) -> set[int]:
+        symbol_ids = {
+            symbol_id
+            for symbol in symbols
+            if (symbol_id := self.sym_index.get(symbol)) is not None
+        }
+        return symbol_ids
 
     def get_runtime_launch_events_mask(self, df: pd.DataFrame) -> pd.Series:
         """Returns a boolean mask you can use with pandas dataframes
         to filter events that are CUDA runtime kernel and memcpy launches."""
-        cudaLaunchKernel_id = self.sym_index.get("cudaLaunchKernel", self.NULL)
-        cudaLaunchKernelExC_id = self.sym_index.get("cudaLaunchKernelExC", self.NULL)
-        cuLaunchKernel_id = self.sym_index.get("cuLaunchKernel", self.NULL)
-        cuLaunchKernelEx_id = self.sym_index.get("cuLaunchKernelEx", self.NULL)
-        cudaMemcpyAsync_id = self.sym_index.get("cudaMemcpyAsync", self.NULL)
-        cudaMemsetAsync_id = self.sym_index.get("cudaMemsetAsync", self.NULL)
-        mtiaLaunchKernel_id = self.sym_index.get(
-            "runFunction - job_prep_and_submit_for_execution", self.NULL
-        )
-        rocmLaunchKernel_id = self.sym_index.get("hipLaunchKernel", self.NULL)
-        rocmExtModuleLaunchKernel_id = self.sym_index.get(
-            "hipExtModuleLaunchKernel", self.NULL
-        )
-        rocmMemsetAsync_id = self.sym_index.get("hipMemsetAsync", self.NULL)
-        rocmMemcpyAsync_id = self.sym_index.get("hipMemcpyAsync", self.NULL)
-        rocmMemcpyWithStream_id = self.sym_index.get("hipMemcpyWithStream", self.NULL)
-
-        # Create a mask for each event type and combine with OR
-        name_mask = (
-            (df["name"] == cudaMemsetAsync_id)
-            | (df["name"] == cudaMemcpyAsync_id)
-            | (df["name"] == cudaLaunchKernel_id)
-            | (df["name"] == cudaLaunchKernelExC_id)
-            | (df["name"] == cuLaunchKernel_id)
-            | (df["name"] == mtiaLaunchKernel_id)
-            | (df["name"] == rocmLaunchKernel_id)
-            | (df["name"] == rocmExtModuleLaunchKernel_id)
-            | (df["name"] == rocmMemcpyAsync_id)
-            | (df["name"] == rocmMemsetAsync_id)
-            | (df["name"] == rocmMemcpyWithStream_id)
-            | (df["name"] == cuLaunchKernelEx_id)
-        )
+        launch_event_ids = self._get_existing_symbol_ids(_RUNTIME_LAUNCH_EVENT_NAMES)
 
         # Add the index_correlation > 0 condition
-        return name_mask & (df["index_correlation"] > 0)
+        return df["name"].isin(launch_event_ids) & (df["index_correlation"] > 0)
 
     def get_events_mask(self, df: pd.DataFrame, events: list[str] | None) -> pd.Series:
         """Returns a boolean mask you can use with pandas dataframes

--- a/tests/test_critical_path_analysis.py
+++ b/tests/test_critical_path_analysis.py
@@ -823,6 +823,56 @@ class CriticalPathAnalysisTestCase(unittest.TestCase):
 
         self.assertTrue(success)
 
+    def test_mtia_trace(self) -> None:
+        """Check MTIA runtime launches are represented in the critical path graph."""
+        trace = TraceAnalysis(trace_dir=get_test_data_dir("mtia_inference_trace"))
+
+        cp_graph, success = trace.critical_path_analysis(
+            rank=0, annotation="", instance_id=None
+        )
+
+        self.assertTrue(success)
+        symbol_ids = cp_graph.symbol_table.get_sym_id_map()
+        self.assertIn("mtia_ccp_events", symbol_ids)
+        mtia_category = symbol_ids["mtia_ccp_events"]
+        runtime_indices = set(
+            cp_graph.trace_df.loc[
+                (cp_graph.trace_df["cat"] == mtia_category)
+                & (cp_graph.trace_df["index_correlation"] > 0),
+                "index_correlation",
+            ].astype(int)
+        )
+        self.assertGreater(len(runtime_indices), 0)
+        self.assertIn("mtia_runtime", symbol_ids)
+        mtia_runtime_indices = set(
+            cp_graph.trace_df.index[
+                cp_graph.trace_df["cat"] == symbol_ids["mtia_runtime"]
+            ]
+        )
+        self.assertTrue(
+            runtime_indices.issubset(mtia_runtime_indices),
+            "Expected every MTIA device-event correlation target to be an "
+            "MTIA runtime event",
+        )
+        for runtime_index in runtime_indices:
+            start_node, end_node = cp_graph.get_nodes_for_event(runtime_index)
+            self.assertIsNotNone(start_node)
+            self.assertIsNotNone(end_node)
+
+        launch_delay_runtime_indices = {
+            cp_graph.get_events_for_edge(data["object"])[0]
+            for _, _, data in cp_graph.edges(data=True)
+            if data["object"].type == CPEdgeType.KERNEL_LAUNCH_DELAY
+        }
+        matching_runtime_indices = runtime_indices & launch_delay_runtime_indices
+        self.assertGreater(
+            len(matching_runtime_indices),
+            0,
+            "Expected a kernel-launch-delay edge sourced from an MTIA runtime "
+            f"event; MTIA runtime indices={sorted(runtime_indices)}, "
+            f"launch-delay sources={sorted(launch_delay_runtime_indices)}",
+        )
+
 
 class EndToEndTestCase(unittest.TestCase):
     """Tests the input / final output (overlaid trace file) of critical path analysis.

--- a/tests/test_trace_symbol_table.py
+++ b/tests/test_trace_symbol_table.py
@@ -86,20 +86,54 @@ class TestTraceSymbolTableUpdateAndAdd(unittest.TestCase):
 
 
 class TestTraceSymbolTableMasks(unittest.TestCase):
-    def test_get_operator_or_cuda_runtime_mask(self) -> None:
+    def test_get_operator_or_device_runtime_mask(self) -> None:
         t = TraceSymbolTable()
-        t.add_symbols(["cpu_op", "cuda_runtime", "cuda_driver", "kernel"])
+        t.add_symbols(
+            [
+                "cpu_op",
+                "cuda_runtime",
+                "cuda_driver",
+                "mtia_runtime",
+                "mtia_runtime_extra",
+                "kernel",
+            ]
+        )
         df = pd.DataFrame(
             {
                 "cat": [
                     t.get_sym_id_map()["cpu_op"],
                     t.get_sym_id_map()["kernel"],
                     t.get_sym_id_map()["cuda_driver"],
+                    t.get_sym_id_map()["cuda_runtime"],
+                    t.get_sym_id_map()["mtia_runtime"],
+                    t.get_sym_id_map()["mtia_runtime_extra"],
                 ]
             }
         )
-        mask = t.get_operator_or_cuda_runtime_mask(df)
-        self.assertEqual(mask.tolist(), [True, False, True])
+        mask = t.get_operator_or_device_runtime_mask(df)
+        self.assertEqual(mask.tolist(), [True, False, True, True, True, False])
+
+    def test_get_operator_or_cuda_runtime_mask(self) -> None:
+        t = TraceSymbolTable()
+        t.add_symbols(
+            ["cpu_op", "cuda_runtime", "cuda_driver", "mtia_runtime", "kernel"]
+        )
+        df = pd.DataFrame(
+            {
+                "cat": [
+                    t.get_sym_id_map()["cpu_op"],
+                    t.get_sym_id_map()["kernel"],
+                    t.get_sym_id_map()["cuda_driver"],
+                    t.get_sym_id_map()["cuda_runtime"],
+                    t.get_sym_id_map()["mtia_runtime"],
+                ]
+            }
+        )
+
+        self.assertEqual(
+            t.get_operator_or_cuda_runtime_mask(df).tolist(),
+            [True, False, True, True, False],
+        )
 
     def test_get_runtime_launch_events_mask(self) -> None:
         t = TraceSymbolTable()


### PR DESCRIPTION
Summary:
**Purpose:** Prevent critical-path analysis from aborting when MTIA device events reference runtime launches.

**Type:** Bug fix

**Changes:**
- Include exact `mtia_runtime` events when critical-path graph nodes are created.
- Build category and launch masks only from symbols that exist, avoiding false matches against encoded NULL values.
- Add fixture-backed MTIA critical-path coverage for correlated runtime nodes and launch-delay edges.

Reviewed By: mengtian-x

Differential Revision: D118713318


